### PR TITLE
[Feat] 일기 작성 api 구현

### DIFF
--- a/src/main/java/org/dallili/secretfriends/SecretFriendsApplication.java
+++ b/src/main/java/org/dallili/secretfriends/SecretFriendsApplication.java
@@ -2,8 +2,10 @@ package org.dallili.secretfriends;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 
 @SpringBootApplication
+@EnableJpaAuditing
 public class SecretFriendsApplication {
 
 	public static void main(String[] args) {

--- a/src/main/java/org/dallili/secretfriends/controller/PageController.java
+++ b/src/main/java/org/dallili/secretfriends/controller/PageController.java
@@ -1,4 +1,45 @@
 package org.dallili.secretfriends.controller;
 
+import io.swagger.v3.oas.annotations.Operation;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.log4j.Log4j2;
+import org.dallili.secretfriends.dto.PageDTO;
+import org.dallili.secretfriends.service.PageService;
+import org.springframework.http.MediaType;
+import org.springframework.validation.BindException;
+import org.springframework.validation.BindingResult;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.HashMap;
+import java.util.Map;
+
+@RestController
+@RequestMapping("/pages")
+@Log4j2
+@RequiredArgsConstructor
 public class PageController {
+
+    private final PageService pageService;
+
+    @Operation(summary = "Pages POST", description = "일기 생성")
+    @PostMapping(value = "/", consumes = MediaType.APPLICATION_JSON_VALUE)
+    public Map<String,Long> pageAdd(@Valid @RequestBody PageDTO pageDTO, BindingResult bindingResult) throws BindException{
+
+        log.info(pageDTO);
+        if(bindingResult.hasErrors()){
+            throw new BindException(bindingResult);
+        }
+
+        Map<String,Long> result = new HashMap<>();
+
+        Long pageId = pageService.addPage(pageDTO);
+        result.put("pageID",pageId);
+
+        return result;
+
+    }
 }

--- a/src/main/java/org/dallili/secretfriends/domain/Page.java
+++ b/src/main/java/org/dallili/secretfriends/domain/Page.java
@@ -1,8 +1,11 @@
 package org.dallili.secretfriends.domain;
 
 import jakarta.persistence.*;
+import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Pattern;
 import lombok.*;
+import org.hibernate.annotations.ColumnDefault;
+import org.hibernate.annotations.DynamicInsert;
 import org.springframework.data.annotation.LastModifiedDate;
 import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 
@@ -18,6 +21,7 @@ import java.time.LocalDateTime;
         @Index(name="idx_page_diary_diaryID", columnList = "diary_diaryID")
 })
 @EntityListeners(value = {AuditingEntityListener.class})
+@DynamicInsert
 public class Page {
 
     @Id
@@ -44,6 +48,14 @@ public class Page {
 
     @Column(name = "state", length = 1)
     @Pattern(regexp = "[YN]", message = "state는 Y 혹은 N 값 중 하나여야 한다.")
-    private String state;
+    @Builder.Default
+    private String state = "N";
+
+    @PrePersist
+    public void defaultState(){
+        if(this.state == null) {
+            this.state = "N";
+        }
+    }
 
 }

--- a/src/main/java/org/dallili/secretfriends/domain/Page.java
+++ b/src/main/java/org/dallili/secretfriends/domain/Page.java
@@ -1,11 +1,11 @@
 package org.dallili.secretfriends.domain;
 
 import jakarta.persistence.*;
+import jakarta.validation.constraints.Pattern;
 import lombok.*;
-import org.springframework.cglib.core.Local;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 
-import java.sql.Timestamp;
-import java.time.LocalDate;
 import java.time.LocalDateTime;
 
 @Entity
@@ -17,21 +17,24 @@ import java.time.LocalDateTime;
 @Table(name = "page", indexes = {
         @Index(name="idx_page_diary_diaryID", columnList = "diary_diaryID")
 })
+@EntityListeners(value = {AuditingEntityListener.class})
 public class Page {
 
     @Id
-    @Column(name = "pageID", length = 20)
-    private String pageID;
+    @Column(name = "pageID")
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long pageID;
 
-    @JoinColumn(name = "diaryID", referencedColumnName = "diaryID", insertable = false, updatable = false)
+    @JoinColumn(name = "diaryID", referencedColumnName = "diaryID", insertable = true, updatable = false)
     @ManyToOne(fetch = FetchType.LAZY) // 여러 개의 페이지가 하나의 다이어리에 속할 수 있음.
     private Diary diary;
 
-    @Column(name = "userID")
-    private String userID;
+    @Column(name = "writer")
+    private String writer;
 
-    @Column(name = "date", columnDefinition = "DATE")
-    private LocalDate date;
+    @Column(name = "date", columnDefinition = "TIMESTAMP")
+    @LastModifiedDate
+    private LocalDateTime date;
 
     @Column(name = "text", columnDefinition = "TEXT")
     private String text;
@@ -39,11 +42,8 @@ public class Page {
     @Column(name = "sendAt", columnDefinition = "TIMESTAMP")
     private LocalDateTime sendAt;
 
-    @Column(name = "state")
-    private char state;
-
-
-
-
+    @Column(name = "state", length = 1)
+    @Pattern(regexp = "[YN]", message = "state는 Y 혹은 N 값 중 하나여야 한다.")
+    private String state;
 
 }

--- a/src/main/java/org/dallili/secretfriends/dto/PageDTO.java
+++ b/src/main/java/org/dallili/secretfriends/dto/PageDTO.java
@@ -1,4 +1,34 @@
 package org.dallili.secretfriends.dto;
 
+import com.fasterxml.jackson.annotation.JsonFormat;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Pattern;
+import jakarta.validation.constraints.Size;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+@Data
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor
 public class PageDTO {
+
+    private Long pageID;
+    @NotBlank
+    private String diaryID;
+    @NotBlank
+    private String writer;
+    @JsonFormat(pattern = "yyyy-MM-dd HH:mm:ss")
+    private LocalDateTime date;
+    @Size(min = 1, message = "일기 내용은 1자 이상 작성해야 한다.")
+    private String text;
+    @JsonFormat(pattern = "yyyy-MM-dd HH:mm:ss")
+    private LocalDateTime sendAt;
+    @Pattern(regexp = "[YN]", message = "state는 Y 혹은 N 값 중 하나여야 한다.")
+    private String state;
+
 }

--- a/src/main/java/org/dallili/secretfriends/repository/PageRepository.java
+++ b/src/main/java/org/dallili/secretfriends/repository/PageRepository.java
@@ -1,0 +1,7 @@
+package org.dallili.secretfriends.repository;
+
+import org.dallili.secretfriends.domain.Page;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface PageRepository extends JpaRepository<Page,Long> {
+}

--- a/src/main/java/org/dallili/secretfriends/service/PageService.java
+++ b/src/main/java/org/dallili/secretfriends/service/PageService.java
@@ -1,4 +1,9 @@
 package org.dallili.secretfriends.service;
 
+import jakarta.transaction.Transactional;
+import org.dallili.secretfriends.dto.PageDTO;
+
+@Transactional
 public interface PageService {
+    Long addPage(PageDTO pageDTO);
 }

--- a/src/main/java/org/dallili/secretfriends/service/PageServiceImpl.java
+++ b/src/main/java/org/dallili/secretfriends/service/PageServiceImpl.java
@@ -1,0 +1,26 @@
+package org.dallili.secretfriends.service;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.log4j.Log4j2;
+import org.dallili.secretfriends.domain.Page;
+import org.dallili.secretfriends.dto.PageDTO;
+import org.dallili.secretfriends.repository.PageRepository;
+import org.modelmapper.ModelMapper;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+@Log4j2
+public class PageServiceImpl implements PageService{
+
+    private final PageRepository pageRepository;
+    private final ModelMapper modelMapper;
+
+    @Override
+    public Long addPage(PageDTO pageDTO) {
+        pageDTO.setState("N");
+        Page page = modelMapper.map(pageDTO,Page.class);
+        Long pid = pageRepository.save(page).getPageID();
+        return pid;
+    }
+}

--- a/src/main/java/org/dallili/secretfriends/service/PageServiceImpl.java
+++ b/src/main/java/org/dallili/secretfriends/service/PageServiceImpl.java
@@ -18,7 +18,6 @@ public class PageServiceImpl implements PageService{
 
     @Override
     public Long addPage(PageDTO pageDTO) {
-        pageDTO.setState("N");
         Page page = modelMapper.map(pageDTO,Page.class);
         Long pid = pageRepository.save(page).getPageID();
         return pid;

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -3,7 +3,8 @@ spring.datasource.url=jdbc:mariadb://localhost:3306/secretfriends
 spring.datasource.username=secretfriends
 spring.datasource.password=secretfriends
 
-logging.level.org.springframework=info
+
+logging.level.org.springframework=debug
 logging.level.org.zerock=debug
 
 spring.jpa.hibernate.ddl-auto=update

--- a/src/test/java/org/dallili/secretfriends/repository/PageRepositoryTests.java
+++ b/src/test/java/org/dallili/secretfriends/repository/PageRepositoryTests.java
@@ -1,0 +1,39 @@
+package org.dallili.secretfriends.repository;
+
+import lombok.extern.log4j.Log4j2;
+import org.dallili.secretfriends.domain.Diary;
+import org.dallili.secretfriends.domain.Page;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.util.stream.IntStream;
+
+@SpringBootTest
+@Log4j2
+public class PageRepositoryTests {
+    @Autowired
+    private PageRepository pageRepository;
+    @Autowired
+    private DiaryRepository diaryRepository;
+
+    @Test
+    public void testInsertPage(){
+        Diary diary = diaryRepository.findById("diary1").orElseThrow();
+
+        IntStream.rangeClosed(1,10).forEach(i->{
+            Page page = Page.builder()
+                    .diary(diary)
+                    .writer(diary.getUser().getUserID())
+                    .date(LocalDateTime.now())
+                    .text("일기 텍스트...")
+                    .sendAt(null)
+                    .state("N")
+                    .build();
+
+            pageRepository.save(page);
+        });
+    }
+}

--- a/src/test/java/org/dallili/secretfriends/repository/PageRepositoryTests.java
+++ b/src/test/java/org/dallili/secretfriends/repository/PageRepositoryTests.java
@@ -27,10 +27,7 @@ public class PageRepositoryTests {
             Page page = Page.builder()
                     .diary(diary)
                     .writer(diary.getUser().getUserID())
-                    .date(LocalDateTime.now())
                     .text("일기 텍스트...")
-                    .sendAt(null)
-                    .state("N")
                     .build();
 
             pageRepository.save(page);

--- a/src/test/java/org/dallili/secretfriends/service/PageServiceTests.java
+++ b/src/test/java/org/dallili/secretfriends/service/PageServiceTests.java
@@ -1,0 +1,32 @@
+package org.dallili.secretfriends.service;
+
+import lombok.extern.log4j.Log4j2;
+import org.dallili.secretfriends.dto.PageDTO;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+
+import java.time.LocalDateTime;
+
+@SpringBootTest
+@Log4j2
+public class PageServiceTests {
+
+    @Autowired
+    private PageService pageService;
+
+    @Test
+    public void testAddPage(){
+
+        PageDTO pageDTO = PageDTO.builder()
+                .diaryID("diary1")
+                .writer("user1")
+                .text("일기")
+                .build();
+
+        Long pid = pageService.addPage(pageDTO);
+
+        log.info(pid);
+    }
+
+}


### PR DESCRIPTION
## 작업 내용
- Page 엔티티 수정
- 일기 작성 api 구현 
- 테스트 코드 작성

## 테스트 여부
- 정상 응답
  <img width="920" alt="image" src="https://github.com/Dallili/secretFriends-api/assets/87927105/62dd486e-affe-40af-b6b2-3b080eb274f5">

- 에러 발생 시 응답 (이후 포맷은 손 볼 예정 . . .)
  <img width="916" alt="image" src="https://github.com/Dallili/secretFriends-api/assets/87927105/1c33e1f4-4bc7-45c1-b534-032f8a48c3a9">

