### PR TITLE
[Feat] 일기 전달 기능 구현

### DIFF
--- a/src/main/java/org/dallili/secretfriends/controller/PageController.java
+++ b/src/main/java/org/dallili/secretfriends/controller/PageController.java
@@ -9,10 +9,7 @@ import org.dallili.secretfriends.service.PageService;
 import org.springframework.http.MediaType;
 import org.springframework.validation.BindException;
 import org.springframework.validation.BindingResult;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 import java.util.HashMap;
 import java.util.Map;
@@ -40,6 +37,19 @@ public class PageController {
         result.put("pageID",pageId);
 
         return result;
+
+    }
+
+    @Operation(summary = "일기 전달", description = "저장된 일기의 state, sendAt 필드 값 업데이트")
+    @PatchMapping(value = "/{pageID}")
+    public Map<String,String> stateModify(@PathVariable("pageID") Long pageID){
+        Boolean result = pageService.modifyState(pageID);
+        if(result){
+            return Map.of("pageID",Long.toString(pageID),
+                    "result","일기 전달 성공");
+        } else 
+            return Map.of("pageID",Long.toString(pageID),
+                    "result","이미 전달된 일기");
 
     }
 }

--- a/src/main/java/org/dallili/secretfriends/repository/PageRepository.java
+++ b/src/main/java/org/dallili/secretfriends/repository/PageRepository.java
@@ -2,6 +2,19 @@ package org.dallili.secretfriends.repository;
 
 import org.dallili.secretfriends.domain.Page;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import java.time.LocalDateTime;
 
 public interface PageRepository extends JpaRepository<Page,Long> {
+    @Modifying
+    @Query("update Page p set p.state = 'Y' where p.pageID = :pageID")
+    int updateState(@Param("pageID") Long pid);
+
+    @Modifying
+    @Query("update Page p set p.sendAt = :sendAt  where p.pageID = :pageID")
+    int updateSendAt(@Param("pageID") Long pid, @Param("sendAt") LocalDateTime sendAt);
+
 }

--- a/src/main/java/org/dallili/secretfriends/service/PageService.java
+++ b/src/main/java/org/dallili/secretfriends/service/PageService.java
@@ -6,4 +6,5 @@ import org.dallili.secretfriends.dto.PageDTO;
 @Transactional
 public interface PageService {
     Long addPage(PageDTO pageDTO);
+    Boolean modifyState(Long pageID);
 }

--- a/src/main/java/org/dallili/secretfriends/service/PageServiceImpl.java
+++ b/src/main/java/org/dallili/secretfriends/service/PageServiceImpl.java
@@ -1,5 +1,6 @@
 package org.dallili.secretfriends.service;
 
+import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.log4j.Log4j2;
 import org.dallili.secretfriends.domain.Page;
@@ -8,9 +9,13 @@ import org.dallili.secretfriends.repository.PageRepository;
 import org.modelmapper.ModelMapper;
 import org.springframework.stereotype.Service;
 
+import java.time.LocalDateTime;
+import java.util.Optional;
+
 @Service
 @RequiredArgsConstructor
 @Log4j2
+@Transactional
 public class PageServiceImpl implements PageService{
 
     private final PageRepository pageRepository;
@@ -21,5 +26,17 @@ public class PageServiceImpl implements PageService{
         Page page = modelMapper.map(pageDTO,Page.class);
         Long pid = pageRepository.save(page).getPageID();
         return pid;
+    }
+
+    @Override
+    public Boolean modifyState(Long pageID) {
+        Optional<Page> pageOptional = pageRepository.findById(pageID);
+        Page page = pageOptional.orElseThrow();
+        if(page.getState().equals("N")){
+            pageRepository.updateState(pageID);
+            pageRepository.updateSendAt(pageID, LocalDateTime.now());
+            return true;
+        } else
+            return false;
     }
 }

--- a/src/test/java/org/dallili/secretfriends/service/PageServiceTests.java
+++ b/src/test/java/org/dallili/secretfriends/service/PageServiceTests.java
@@ -29,4 +29,10 @@ public class PageServiceTests {
         log.info(pid);
     }
 
+    @Test
+    public void testModifyState(){
+        Long pid = 54L;
+        pageService.modifyState(pid);
+    }
+
 }

--- a/src/test/java/org/dallili/secretfriends/service/PageServiceTests.java
+++ b/src/test/java/org/dallili/secretfriends/service/PageServiceTests.java
@@ -31,8 +31,9 @@ public class PageServiceTests {
 
     @Test
     public void testModifyState(){
-        Long pid = 54L;
-        pageService.modifyState(pid);
+        Long pid = 40L;
+        Boolean result = pageService.modifyState(pid);
+        log.info(result);
     }
 
 }


### PR DESCRIPTION
## 작업 내용
- 일기 전달 api 구현
- 테스트 코드 작성

## 구현 방법
save() 메서드를 통해 state와 sendAt 필드의 값을 업데이트할 시 date 필드의 값이 같이 업데이트 되는 문제 발생
→ PageRepository에 메서드를 수동으로 등록해 state, sendAt 만 업데이트 되도록 구현함

## 테스트 여부
- 정상 응답 [1] 아직 전달되지 않은 일기의 id와 함께 요청
  <img width="935" alt="image" src="https://github.com/Dallili/secretFriends-api/assets/87927105/0907b67e-d177-43b1-b82e-82d00e93dcc8">

- 정상 응답 [2] 이미 전달된 일기의 id와 함께 요청
  <img width="929" alt="image" src="https://github.com/Dallili/secretFriends-api/assets/87927105/b2a558fc-9fd1-4c45-a233-6f70d4c13fcb">

- 에러 응답 ex. 존재하지 않는 일기의 id 와 함께 요청
{
  "timestamp": "2024-03-26T05:20:14.804+00:00",
  "status": 500,
  "error": "Internal Server Error",
  "trace": "java.ut..." 
  "message": "No value present",
  "path": "/pages/1"
}