### PR TITLE
[feat] 일기장 기능 구현

### DIFF
--- a/src/main/java/org/dallili/secretfriends/config/RootConfig.java
+++ b/src/main/java/org/dallili/secretfriends/config/RootConfig.java
@@ -1,6 +1,9 @@
 package org.dallili.secretfriends.config;
 
+import org.dallili.secretfriends.domain.Diary;
+import org.dallili.secretfriends.dto.DiaryDTO;
 import org.modelmapper.ModelMapper;
+import org.modelmapper.PropertyMap;
 import org.modelmapper.convention.MatchingStrategies;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -16,7 +19,23 @@ public class RootConfig {
                 .setFieldMatchingEnabled(true)
                 .setFieldAccessLevel(org.modelmapper.config.Configuration.AccessLevel.PRIVATE)
                 .setMatchingStrategy(MatchingStrategies.LOOSE);
-
+        modelMapper.addMappings(diaryMapping);
         return modelMapper;
     }
+
+    PropertyMap<DiaryDTO, Diary> diaryMapping = new PropertyMap<DiaryDTO, Diary>() {
+        @Override
+        protected void configure() {
+            map().getUser().setUserID(source.getUserID());
+            map().getPartner().setUserID(source.getPartnerID());
+        }
+    };
+
+    PropertyMap<Diary,DiaryDTO> diaryFieldMapping = new PropertyMap<Diary, DiaryDTO>() {
+        @Override
+        protected void configure() {
+            map().setUserID(source.getUser().getUserID());
+            map().setPartnerID(source.getPartner().getUserID());
+        }
+    };
 }

--- a/src/main/java/org/dallili/secretfriends/controller/DiaryController.java
+++ b/src/main/java/org/dallili/secretfriends/controller/DiaryController.java
@@ -1,4 +1,43 @@
 package org.dallili.secretfriends.controller;
 
+
+import io.swagger.v3.oas.annotations.Operation;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.log4j.Log4j2;
+import org.dallili.secretfriends.dto.DiaryDTO;
+import org.dallili.secretfriends.repository.DiaryRepository;
+import org.dallili.secretfriends.service.DiaryService;
+import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Controller
+@Log4j2
+@RequiredArgsConstructor
+@RequestMapping("/diaries")
 public class DiaryController {
+
+
+    private final DiaryService diaryService;
+
+    @Operation(summary = "Diary List GET", description = "활성/비활성 일기장 목록 조회")
+    @GetMapping(value = "/{state}")
+    public List<DiaryDTO> diaryDTOList (@PathVariable("state") Boolean state, String userID) {
+        List<DiaryDTO> diaries = diaryService.findAllDiaries()
+                .stream()
+                .filter(diaryDTO -> diaryDTO.isActivated() == state)
+                .filter(diaryDTO -> userID.equals(diaryDTO.getUserID()) || userID.equals(diaryDTO.getPartnerID()))
+                .collect(Collectors.toList());
+
+        log.info(state+ "상태인 일기장 목록: " + diaries);
+        return diaries;
+    }
+
+
+
+
 }

--- a/src/main/java/org/dallili/secretfriends/controller/DiaryController.java
+++ b/src/main/java/org/dallili/secretfriends/controller/DiaryController.java
@@ -32,7 +32,6 @@ public class DiaryController {
                 .filter(diaryDTO -> diaryDTO.isActivated() == state)
                 .filter(diaryDTO -> userID.equals(diaryDTO.getUserID()) || userID.equals(diaryDTO.getPartnerID()))
                 .collect(Collectors.toList());
-
         log.info(state+ "상태인 일기장 목록: " + diaries);
         return diaries;
     }

--- a/src/main/java/org/dallili/secretfriends/domain/Diary.java
+++ b/src/main/java/org/dallili/secretfriends/domain/Diary.java
@@ -8,7 +8,6 @@ import java.time.LocalDateTime;
 //엔티티 객체를 위한 엔티티 클래스는 반드시 @Entity를 적용해야하고 @Id가 필요하다
 @Entity
 @Getter
-@Setter
 @Builder
 @AllArgsConstructor
 @NoArgsConstructor
@@ -43,6 +42,25 @@ public class Diary{
     public void updateDiary(String updatedBy, LocalDateTime updatedAt){
         this.updatedBy = updatedBy;
         this.updatedAt = updatedAt;
+    }
+
+    public void decidePartner(User partner){
+        this.partner = partner;
+    }
+
+    public void changeState(Boolean state){
+        this.isActivated = state;
+    }
+
+
+    //modelmapper 매핑 규칙 정의를 위한 setter
+    //일반 코드 작성 시에는 사용 지양
+    public void setUser(User user){
+        this.user = user;
+    }
+
+    public void setPartner(User partner){
+        this.partner = partner;
     }
 
 

--- a/src/main/java/org/dallili/secretfriends/domain/Diary.java
+++ b/src/main/java/org/dallili/secretfriends/domain/Diary.java
@@ -8,6 +8,7 @@ import java.time.LocalDateTime;
 //엔티티 객체를 위한 엔티티 클래스는 반드시 @Entity를 적용해야하고 @Id가 필요하다
 @Entity
 @Getter
+@Setter
 @Builder
 @AllArgsConstructor
 @NoArgsConstructor

--- a/src/main/java/org/dallili/secretfriends/domain/Diary.java
+++ b/src/main/java/org/dallili/secretfriends/domain/Diary.java
@@ -25,7 +25,7 @@ public class Diary{
     private User user;
 
     @ManyToOne(fetch = FetchType.LAZY) //여러 개의 diary가 하나의 user에 속할 수 있음
-    @JoinColumn(name = "partnerID", referencedColumnName = "userID", insertable = true, updatable = false)
+    @JoinColumn(name = "partnerID", referencedColumnName = "userID", insertable = true, updatable = true)
     private User partner;
 
     @Column(name = "isActivated",columnDefinition = "TINYINT")
@@ -39,13 +39,6 @@ public class Diary{
 
     @Column(name = "color", length = 7)
     private String color;
-
-    public void decidePartner(User partner){
-        this.partner = partner;
-    }
-    public void changeState(boolean isActivated){
-        this.isActivated = isActivated;
-    }
 
     public void updateDiary(String updatedBy, LocalDateTime updatedAt){
         this.updatedBy = updatedBy;

--- a/src/main/java/org/dallili/secretfriends/domain/Diary.java
+++ b/src/main/java/org/dallili/secretfriends/domain/Diary.java
@@ -39,6 +39,17 @@ public class Diary{
     @Column(name = "color", length = 7)
     private String color;
 
+    public void decidePartner(User partner){
+        this.partner = partner;
+    }
+    public void changeState(boolean isActivated){
+        this.isActivated = isActivated;
+    }
+
+    public void updateDiary(String updatedBy, LocalDateTime updatedAt){
+        this.updatedBy = updatedBy;
+        this.updatedAt = updatedAt;
+    }
 
 
 

--- a/src/main/java/org/dallili/secretfriends/domain/User.java
+++ b/src/main/java/org/dallili/secretfriends/domain/User.java
@@ -10,6 +10,7 @@ import java.util.Date;
 
 @Entity
 @Getter
+@Setter
 @Builder
 @AllArgsConstructor
 @NoArgsConstructor

--- a/src/main/java/org/dallili/secretfriends/domain/User.java
+++ b/src/main/java/org/dallili/secretfriends/domain/User.java
@@ -10,7 +10,6 @@ import java.util.Date;
 
 @Entity
 @Getter
-@Setter
 @Builder
 @AllArgsConstructor
 @NoArgsConstructor
@@ -39,5 +38,12 @@ public class User {
 
     @Column(name = "useFiltering",columnDefinition = "TINYINT")
     private boolean useFiltering;
+
+    //modelmapper 매핑 규칙 정의를 위한 setter
+    //일반 코드 작성 시에는 사용 지양
+
+    public void setUserID(String userID){
+        this.userID = userID;
+    }
 
 }

--- a/src/main/java/org/dallili/secretfriends/dto/DiaryDTO.java
+++ b/src/main/java/org/dallili/secretfriends/dto/DiaryDTO.java
@@ -37,5 +37,4 @@ public class DiaryDTO {
     private String color; //get
 
 
-
 }

--- a/src/main/java/org/dallili/secretfriends/dto/DiaryDTO.java
+++ b/src/main/java/org/dallili/secretfriends/dto/DiaryDTO.java
@@ -1,4 +1,41 @@
 package org.dallili.secretfriends.dto;
 
+import com.fasterxml.jackson.annotation.JsonFormat;
+import jakarta.persistence.*;
+import jakarta.validation.constraints.NotEmpty;
+import jakarta.validation.constraints.NotNull;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import org.dallili.secretfriends.domain.User;
+
+import java.time.LocalDateTime;
+
+@Data
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor
+
 public class DiaryDTO {
+
+    @NotNull
+    private String diaryID; //get
+
+    @NotEmpty
+    private User user; //get, set
+
+    private User partner; //get, set
+
+    private boolean isActivated; //get, set
+
+    private String updatedBy; //get. set
+
+    @JsonFormat(pattern = "yyyy-MM-dd HH:mm:ss")
+    private LocalDateTime updatedAt; // get, set
+
+    private String color; //get
+
+
+
 }

--- a/src/main/java/org/dallili/secretfriends/dto/DiaryDTO.java
+++ b/src/main/java/org/dallili/secretfriends/dto/DiaryDTO.java
@@ -23,9 +23,9 @@ public class DiaryDTO {
     private String diaryID; //get
 
     @NotEmpty
-    private User user; //get, set
+    private String userID; //get, set
 
-    private User partner; //get, set
+    private String partnerID; //get, set
 
     private boolean isActivated; //get, set
 

--- a/src/main/java/org/dallili/secretfriends/dto/DiaryDTO.java
+++ b/src/main/java/org/dallili/secretfriends/dto/DiaryDTO.java
@@ -23,9 +23,9 @@ public class DiaryDTO {
     private String diaryID; //get
 
     @NotEmpty
-    private String userID; //get, set
+    private User user; //get, set
 
-    private String partnerID; //get, set
+    private User partner; //get, set
 
     private boolean isActivated; //get, set
 

--- a/src/main/java/org/dallili/secretfriends/service/DiaryService.java
+++ b/src/main/java/org/dallili/secretfriends/service/DiaryService.java
@@ -7,9 +7,13 @@ public interface DiaryService {
 
     String register(DiaryDTO diaryDTO); // 일기장 등록
 
-    Diary readOne(String diaryID); // 일기장 조회
+    DiaryDTO readOne(String diaryID); // 일기장 조회
 
-    void modify(DiaryDTO diaryDTO); // 일기장 수정
+    void update(DiaryDTO diaryDTO); // 일기장 업데이트 (새로운 답장)
 
     void remove(String diaryID); // 일기장 삭제
+
+    void modifyPartner(DiaryDTO diaryDTO); // 일기장 파트너 결정
+
+    void modifyState(DiaryDTO diaryDTO); // 일기장 활성화 상태 변경
 }

--- a/src/main/java/org/dallili/secretfriends/service/DiaryService.java
+++ b/src/main/java/org/dallili/secretfriends/service/DiaryService.java
@@ -6,13 +6,13 @@ import org.dallili.secretfriends.dto.DiaryDTO;
 import java.util.List;
 public interface DiaryService {
 
-    String register(DiaryDTO diaryDTO); // 일기장 등록
+    String addDiary(DiaryDTO diaryDTO); // 일기장 등록
 
-    DiaryDTO readOne(String diaryID); // 일기장 조회
+    DiaryDTO findOne(String diaryID); // 일기장 조회
 
-    void update(DiaryDTO diaryDTO); // 일기장 업데이트 (새로운 답장)
+    void modifyUpdate(DiaryDTO diaryDTO); // 일기장 업데이트 (새로운 답장)
 
-    void remove(String diaryID); // 일기장 삭제
+    void removeDiary(String diaryID); // 일기장 삭제
 
     List<DiaryDTO> findAllDiaries();
 

--- a/src/main/java/org/dallili/secretfriends/service/DiaryService.java
+++ b/src/main/java/org/dallili/secretfriends/service/DiaryService.java
@@ -15,5 +15,5 @@ public interface DiaryService {
 
     void modifyPartner(DiaryDTO diaryDTO); // 일기장 파트너 결정
 
-    void modifyState(DiaryDTO diaryDTO); // 일기장 활성화 상태 변경
+    void modifyState(DiaryDTO diaryDTO); // 일기장 활성화 상태 변경 (비활성화)
 }

--- a/src/main/java/org/dallili/secretfriends/service/DiaryService.java
+++ b/src/main/java/org/dallili/secretfriends/service/DiaryService.java
@@ -3,6 +3,7 @@ package org.dallili.secretfriends.service;
 import org.dallili.secretfriends.domain.Diary;
 import org.dallili.secretfriends.dto.DiaryDTO;
 
+import java.util.List;
 public interface DiaryService {
 
     String register(DiaryDTO diaryDTO); // 일기장 등록
@@ -13,6 +14,7 @@ public interface DiaryService {
 
     void remove(String diaryID); // 일기장 삭제
 
+    List<DiaryDTO> findAllDiaries();
 
     void modifyPartner(String diaryID, String partnerID); // 일기장 파트너 결정
 

--- a/src/main/java/org/dallili/secretfriends/service/DiaryService.java
+++ b/src/main/java/org/dallili/secretfriends/service/DiaryService.java
@@ -6,14 +6,15 @@ import org.dallili.secretfriends.dto.DiaryDTO;
 public interface DiaryService {
 
     String register(DiaryDTO diaryDTO); // 일기장 등록
-/*
+
     DiaryDTO readOne(String diaryID); // 일기장 조회
 
     void update(DiaryDTO diaryDTO); // 일기장 업데이트 (새로운 답장)
 
     void remove(String diaryID); // 일기장 삭제
 
-    void modifyPartner(DiaryDTO diaryDTO); // 일기장 파트너 결정
 
-    void modifyState(DiaryDTO diaryDTO); // 일기장 활성화 상태 변경 (비활성화)*/
+    void modifyPartner(String diaryID, String partnerID); // 일기장 파트너 결정
+
+    void modifyState(String diaryID); // 일기장 비활성화
 }

--- a/src/main/java/org/dallili/secretfriends/service/DiaryService.java
+++ b/src/main/java/org/dallili/secretfriends/service/DiaryService.java
@@ -6,7 +6,7 @@ import org.dallili.secretfriends.dto.DiaryDTO;
 public interface DiaryService {
 
     String register(DiaryDTO diaryDTO); // 일기장 등록
-
+/*
     DiaryDTO readOne(String diaryID); // 일기장 조회
 
     void update(DiaryDTO diaryDTO); // 일기장 업데이트 (새로운 답장)
@@ -15,5 +15,5 @@ public interface DiaryService {
 
     void modifyPartner(DiaryDTO diaryDTO); // 일기장 파트너 결정
 
-    void modifyState(DiaryDTO diaryDTO); // 일기장 활성화 상태 변경 (비활성화)
+    void modifyState(DiaryDTO diaryDTO); // 일기장 활성화 상태 변경 (비활성화)*/
 }

--- a/src/main/java/org/dallili/secretfriends/service/DiaryService.java
+++ b/src/main/java/org/dallili/secretfriends/service/DiaryService.java
@@ -1,4 +1,15 @@
 package org.dallili.secretfriends.service;
 
+import org.dallili.secretfriends.domain.Diary;
+import org.dallili.secretfriends.dto.DiaryDTO;
+
 public interface DiaryService {
+
+    String register(DiaryDTO diaryDTO); // 일기장 등록
+
+    Diary readOne(String diaryID); // 일기장 조회
+
+    void modify(DiaryDTO diaryDTO); // 일기장 수정
+
+    void remove(String diaryID); // 일기장 삭제
 }

--- a/src/main/java/org/dallili/secretfriends/service/DiaryServiceImpl.java
+++ b/src/main/java/org/dallili/secretfriends/service/DiaryServiceImpl.java
@@ -17,11 +17,9 @@ import java.util.Optional;
 @Service
 @Log4j2
 @RequiredArgsConstructor
-@Transactional
 public class DiaryServiceImpl implements DiaryService {
 
     private final ModelMapper modelMapper;
-
 
     private final DiaryRepository diaryRepository;
 
@@ -37,6 +35,7 @@ public class DiaryServiceImpl implements DiaryService {
         return diaryID;
     }
 
+    /*
     @Override
     public DiaryDTO readOne(String diaryID){
 
@@ -52,15 +51,20 @@ public class DiaryServiceImpl implements DiaryService {
     }
 
     @Override
-    public void update(DiaryDTO diaryDTO) {
+    public void update(DiaryDTO diaryDTO) { //일기 전송 후 작동해야하는 메소드.
+        // 마지막 작성자와 마지막 작성일을 수정한다.
 
         Optional<Diary> result = diaryRepository.findById(diaryDTO.getDiaryID());
 
         Diary diary = result.orElseThrow();
 
+        log.info("업데이트 전: " + diary);
+
         diary.updateDiary(diaryDTO.getUpdatedBy(), diaryDTO.getUpdatedAt());
 
         diaryRepository.save(diary);
+
+        log.info("업데이트 후: " + diary);
 
 
     }
@@ -100,6 +104,6 @@ public class DiaryServiceImpl implements DiaryService {
 
         diaryRepository.save(diary);
 
-    }
+    }*/
 
 }

--- a/src/main/java/org/dallili/secretfriends/service/DiaryServiceImpl.java
+++ b/src/main/java/org/dallili/secretfriends/service/DiaryServiceImpl.java
@@ -20,7 +20,8 @@ import java.util.Optional;
 @Transactional
 public class DiaryServiceImpl implements DiaryService {
 
-    private ModelMapper modelMapper;
+    private final ModelMapper modelMapper;
+
 
     private final DiaryRepository diaryRepository;
 
@@ -79,7 +80,7 @@ public class DiaryServiceImpl implements DiaryService {
 
         Diary diary = result.orElseThrow();
 
-        Optional<User> partnerResult = userRepository.findById(diaryDTO.getPartnerID());
+        Optional<User> partnerResult = userRepository.findById(diaryDTO.getPartner().getUserID());
 
         User partner = partnerResult.orElseThrow();
 

--- a/src/main/java/org/dallili/secretfriends/service/DiaryServiceImpl.java
+++ b/src/main/java/org/dallili/secretfriends/service/DiaryServiceImpl.java
@@ -1,0 +1,96 @@
+package org.dallili.secretfriends.service;
+
+import jakarta.transaction.Transactional;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.log4j.Log4j2;
+import org.dallili.secretfriends.domain.Diary;
+import org.dallili.secretfriends.dto.DiaryDTO;
+import org.dallili.secretfriends.repository.DiaryRepository;
+import org.modelmapper.ModelMapper;
+import org.springframework.stereotype.Service;
+
+import java.util.Optional;
+
+@Service
+@Log4j2
+@RequiredArgsConstructor
+@Transactional
+public class DiaryServiceImpl implements DiaryService {
+
+    private ModelMapper modelMapper;
+
+    private final DiaryRepository diaryRepository;
+
+    @Override
+    public String register(DiaryDTO diaryDTO) {
+
+        Diary diary = modelMapper.map(diaryDTO, Diary.class);
+
+        String diaryID = diaryRepository.save(diary).getDiaryID();
+
+        return diaryID;
+    }
+
+    @Override
+    public DiaryDTO readOne(String diaryID){
+
+        Optional<Diary> result = diaryRepository.findById(diaryID);
+
+        Diary diary = result.orElseThrow();
+
+        DiaryDTO diaryDTO = modelMapper.map(diary, DiaryDTO.class);
+
+        //좀 더 개발 후에 pageDTO도 함께 다뤄야 함
+        return diaryDTO;
+
+    }
+
+    @Override
+    public void update(DiaryDTO diaryDTO) {
+
+        Optional<Diary> result = diaryRepository.findById(diaryDTO.getDiaryID());
+
+        Diary diary = result.orElseThrow();
+
+        diary.updateDiary(diaryDTO.getUpdatedBy(), diaryDTO.getUpdatedAt());
+
+        diaryRepository.save(diary);
+
+
+    }
+
+
+    @Override
+    public void remove(String diaryID) {
+
+        diaryRepository.deleteById(diaryID);
+
+    }
+
+    @Override
+    public void modifyPartner(DiaryDTO diaryDTO){
+
+        Optional<Diary> result = diaryRepository.findById(diaryDTO.getDiaryID());
+
+        Diary diary = result.orElseThrow();
+
+        diary.decidePartner(diaryDTO.getPartner());
+
+        diaryRepository.save(diary);
+
+    }
+
+    @Override
+    public void modifyState(DiaryDTO diaryDTO){
+
+        Optional<Diary> result = diaryRepository.findById(diaryDTO.getDiaryID());
+
+        Diary diary = result.orElseThrow();
+
+        diary.changeState(diaryDTO.isActivated());
+
+        diaryRepository.save(diary);
+
+    }
+
+}

--- a/src/main/java/org/dallili/secretfriends/service/DiaryServiceImpl.java
+++ b/src/main/java/org/dallili/secretfriends/service/DiaryServiceImpl.java
@@ -4,8 +4,11 @@ import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.log4j.Log4j2;
 import org.dallili.secretfriends.domain.Diary;
+import org.dallili.secretfriends.domain.User;
 import org.dallili.secretfriends.dto.DiaryDTO;
+import org.dallili.secretfriends.dto.UserDTO;
 import org.dallili.secretfriends.repository.DiaryRepository;
+import org.dallili.secretfriends.repository.UserRepository;
 import org.modelmapper.ModelMapper;
 import org.springframework.stereotype.Service;
 
@@ -20,6 +23,8 @@ public class DiaryServiceImpl implements DiaryService {
     private ModelMapper modelMapper;
 
     private final DiaryRepository diaryRepository;
+
+    private final UserRepository userRepository;
 
     @Override
     public String register(DiaryDTO diaryDTO) {
@@ -74,10 +79,13 @@ public class DiaryServiceImpl implements DiaryService {
 
         Diary diary = result.orElseThrow();
 
-        diary.decidePartner(diaryDTO.getPartner());
+        Optional<User> partnerResult = userRepository.findById(diaryDTO.getPartnerID());
+
+        User partner = partnerResult.orElseThrow();
+
+        diary.decidePartner(partner);
 
         diaryRepository.save(diary);
-
     }
 
     @Override

--- a/src/main/java/org/dallili/secretfriends/service/DiaryServiceImpl.java
+++ b/src/main/java/org/dallili/secretfriends/service/DiaryServiceImpl.java
@@ -35,7 +35,7 @@ public class DiaryServiceImpl implements DiaryService {
         return diaryID;
     }
 
-    /*
+
     @Override
     public DiaryDTO readOne(String diaryID){
 
@@ -58,13 +58,13 @@ public class DiaryServiceImpl implements DiaryService {
 
         Diary diary = result.orElseThrow();
 
-        log.info("업데이트 전: " + diary);
+        //log.info("업데이트 전: " + diary);
 
         diary.updateDiary(diaryDTO.getUpdatedBy(), diaryDTO.getUpdatedAt());
 
         diaryRepository.save(diary);
 
-        log.info("업데이트 후: " + diary);
+        //log.info("업데이트 후: " + diary);
 
 
     }
@@ -77,33 +77,35 @@ public class DiaryServiceImpl implements DiaryService {
 
     }
 
-    @Override
-    public void modifyPartner(DiaryDTO diaryDTO){
 
-        Optional<Diary> result = diaryRepository.findById(diaryDTO.getDiaryID());
+
+    @Override
+    public void modifyPartner(String diaryID, String partnerID){
+
+        Optional<Diary> result = diaryRepository.findById(diaryID);
 
         Diary diary = result.orElseThrow();
 
-        Optional<User> partnerResult = userRepository.findById(diaryDTO.getPartner().getUserID());
+        Optional<User> partnerResult = userRepository.findById(partnerID);
 
         User partner = partnerResult.orElseThrow();
 
-        diary.decidePartner(partner);
+        diary.setPartner(partner);
 
         diaryRepository.save(diary);
     }
 
     @Override
-    public void modifyState(DiaryDTO diaryDTO){
+    public void modifyState(String diaryID) {
 
-        Optional<Diary> result = diaryRepository.findById(diaryDTO.getDiaryID());
+        Optional<Diary> result = diaryRepository.findById(diaryID);
 
         Diary diary = result.orElseThrow();
 
-        diary.changeState(diaryDTO.isActivated());
+        diary.setActivated(false);
 
         diaryRepository.save(diary);
 
-    }*/
+    }
 
 }

--- a/src/main/java/org/dallili/secretfriends/service/DiaryServiceImpl.java
+++ b/src/main/java/org/dallili/secretfriends/service/DiaryServiceImpl.java
@@ -92,7 +92,7 @@ public class DiaryServiceImpl implements DiaryService {
 
         User partner = partnerResult.orElseThrow();
 
-        diary.setPartner(partner);
+        diary.decidePartner(partner);
 
         diaryRepository.save(diary);
     }
@@ -104,7 +104,7 @@ public class DiaryServiceImpl implements DiaryService {
 
         Diary diary = result.orElseThrow();
 
-        diary.setActivated(false);
+        diary.changeState(false);
 
         diaryRepository.save(diary);
 

--- a/src/main/java/org/dallili/secretfriends/service/DiaryServiceImpl.java
+++ b/src/main/java/org/dallili/secretfriends/service/DiaryServiceImpl.java
@@ -12,7 +12,9 @@ import org.dallili.secretfriends.repository.UserRepository;
 import org.modelmapper.ModelMapper;
 import org.springframework.stereotype.Service;
 
+import java.util.List;
 import java.util.Optional;
+import java.util.stream.Collectors;
 
 @Service
 @Log4j2
@@ -105,6 +107,17 @@ public class DiaryServiceImpl implements DiaryService {
         diary.setActivated(false);
 
         diaryRepository.save(diary);
+
+    }
+
+    @Override
+    public List<DiaryDTO> findAllDiaries() {
+
+        List<Diary> diaries = diaryRepository.findAll();
+
+        return diaries.stream()
+                .map(diary -> modelMapper.map(diary, DiaryDTO.class) )
+                .collect(Collectors.toList());
 
     }
 

--- a/src/main/java/org/dallili/secretfriends/service/DiaryServiceImpl.java
+++ b/src/main/java/org/dallili/secretfriends/service/DiaryServiceImpl.java
@@ -12,6 +12,7 @@ import org.dallili.secretfriends.repository.UserRepository;
 import org.modelmapper.ModelMapper;
 import org.springframework.stereotype.Service;
 
+import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Optional;
 import java.util.stream.Collectors;
@@ -28,7 +29,7 @@ public class DiaryServiceImpl implements DiaryService {
     private final UserRepository userRepository;
 
     @Override
-    public String register(DiaryDTO diaryDTO) {
+    public String addDiary(DiaryDTO diaryDTO) {
 
         Diary diary = modelMapper.map(diaryDTO, Diary.class);
 
@@ -39,7 +40,7 @@ public class DiaryServiceImpl implements DiaryService {
 
 
     @Override
-    public DiaryDTO readOne(String diaryID){
+    public DiaryDTO findOne(String diaryID){
 
         Optional<Diary> result = diaryRepository.findById(diaryID);
 
@@ -47,13 +48,12 @@ public class DiaryServiceImpl implements DiaryService {
 
         DiaryDTO diaryDTO = modelMapper.map(diary, DiaryDTO.class);
 
-        //좀 더 개발 후에 pageDTO도 함께 다뤄야 함
         return diaryDTO;
 
     }
 
     @Override
-    public void update(DiaryDTO diaryDTO) { //일기 전송 후 작동해야하는 메소드.
+    public void modifyUpdate(DiaryDTO diaryDTO) { //일기 전송 후 작동해야하는 메소드.
         // 마지막 작성자와 마지막 작성일을 수정한다.
 
         Optional<Diary> result = diaryRepository.findById(diaryDTO.getDiaryID());
@@ -62,7 +62,7 @@ public class DiaryServiceImpl implements DiaryService {
 
         //log.info("업데이트 전: " + diary);
 
-        diary.updateDiary(diaryDTO.getUpdatedBy(), diaryDTO.getUpdatedAt());
+        diary.updateDiary(diaryDTO.getUpdatedBy(), LocalDateTime.now());
 
         diaryRepository.save(diary);
 
@@ -73,7 +73,7 @@ public class DiaryServiceImpl implements DiaryService {
 
 
     @Override
-    public void remove(String diaryID) {
+    public void removeDiary(String diaryID) {
 
         diaryRepository.deleteById(diaryID);
 

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -4,8 +4,8 @@ spring.datasource.username=secretfriends
 spring.datasource.password=secretfriends
 
 
-logging.level.org.springframework=debug
-logging.level.org.zerock=debug
+logging.level.org.springframework=info
+logging.level.org.dallili=debug
 
 spring.jpa.hibernate.ddl-auto=update
 spring.jpa.properties.hibernate.format_sql=true

--- a/src/test/java/org/dallili/secretfriends/service/DiaryServiceTests.java
+++ b/src/test/java/org/dallili/secretfriends/service/DiaryServiceTests.java
@@ -1,0 +1,41 @@
+package org.dallili.secretfriends.service;
+
+import lombok.extern.log4j.Log4j2;
+import org.dallili.secretfriends.domain.User;
+import org.dallili.secretfriends.dto.DiaryDTO;
+import org.dallili.secretfriends.repository.UserRepository;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+
+import java.time.LocalDateTime;
+import java.util.Optional;
+
+@SpringBootTest
+@Log4j2
+public class DiaryServiceTests {
+
+    @Autowired
+    private DiaryService diaryService;
+    @Autowired
+    private UserRepository userRepository;
+
+    @Test
+    public void testRegister() {
+
+        Optional<User> user = userRepository.findById("user1");
+        Optional<User> partner = userRepository.findById("user10");
+
+               DiaryDTO diaryDTO = DiaryDTO.builder()
+                .diaryID("diary101")
+                .color("#123456")
+                .isActivated(true)
+                .user(user.orElseThrow())
+                .partner(partner.orElseThrow())
+                .updatedBy("user10")
+                .updatedAt(LocalDateTime.now())
+                        .build();
+
+        log.info(diaryService.register(diaryDTO));
+    }
+}

--- a/src/test/java/org/dallili/secretfriends/service/DiaryServiceTests.java
+++ b/src/test/java/org/dallili/secretfriends/service/DiaryServiceTests.java
@@ -38,14 +38,14 @@ public class DiaryServiceTests {
                 .build();
 
 
-        log.info(diaryService.register(diaryDTO));
+        log.info(diaryService.addDiary(diaryDTO));
     }
 
 
     @Test
     public void testReadOne() {
 
-        DiaryDTO diaryDTO = diaryService.readOne("diary4");
+        DiaryDTO diaryDTO = diaryService.findOne("diary4");
 
         log.info(diaryDTO);
     }
@@ -55,19 +55,18 @@ public class DiaryServiceTests {
 
         DiaryDTO diaryDTO = DiaryDTO.builder()
                 .diaryID("diary10")
-                .updatedAt(LocalDateTime.now())
                 .updatedBy("new user")
                 .build();
 
         log.info("업데이트 할 것 : "+ diaryDTO);
 
-        diaryService.update(diaryDTO);
+        diaryService.modifyUpdate(diaryDTO);
     }
 
     @Test
     public void testRemove() {
 
-        diaryService.remove("diary1");
+        diaryService.removeDiary("diary1");
 
     }
 

--- a/src/test/java/org/dallili/secretfriends/service/DiaryServiceTests.java
+++ b/src/test/java/org/dallili/secretfriends/service/DiaryServiceTests.java
@@ -1,4 +1,0 @@
-package org.dallili.secretfriends.service;
-
-public class DiaryServiceTests {
-}

--- a/src/test/java/org/dallili/secretfriends/service/DiaryServiceTests.java
+++ b/src/test/java/org/dallili/secretfriends/service/DiaryServiceTests.java
@@ -1,5 +1,6 @@
 package org.dallili.secretfriends.service;
 
+import jakarta.transaction.Transactional;
 import lombok.extern.log4j.Log4j2;
 import org.dallili.secretfriends.domain.User;
 import org.dallili.secretfriends.dto.DiaryDTO;
@@ -11,6 +12,7 @@ import org.springframework.boot.test.context.SpringBootTest;
 import java.time.LocalDateTime;
 import java.util.Optional;
 
+@Transactional
 @SpringBootTest
 @Log4j2
 public class DiaryServiceTests {
@@ -37,5 +39,13 @@ public class DiaryServiceTests {
                         .build();
 
         log.info(diaryService.register(diaryDTO));
+    }
+
+    @Test
+    public void testReadOne() {
+
+        DiaryDTO diaryDTO = diaryService.readOne("diary4");
+
+        log.info(diaryDTO);
     }
 }

--- a/src/test/java/org/dallili/secretfriends/service/DiaryServiceTests.java
+++ b/src/test/java/org/dallili/secretfriends/service/DiaryServiceTests.java
@@ -83,4 +83,11 @@ public class DiaryServiceTests {
 
         diaryService.modifyState("diary10");
     }
+
+    @Test
+    public void testFindAllDiaries() {
+
+        log.info(diaryService.findAllDiaries());
+
+    }
 }

--- a/src/test/java/org/dallili/secretfriends/service/DiaryServiceTests.java
+++ b/src/test/java/org/dallili/secretfriends/service/DiaryServiceTests.java
@@ -1,0 +1,4 @@
+package org.dallili.secretfriends.service;
+
+public class DiaryServiceTests {
+}

--- a/src/test/java/org/dallili/secretfriends/service/DiaryServiceTests.java
+++ b/src/test/java/org/dallili/secretfriends/service/DiaryServiceTests.java
@@ -28,7 +28,7 @@ public class DiaryServiceTests {
         //Optional<User> partner = userRepository.findById("user10");
 
         DiaryDTO diaryDTO = DiaryDTO.builder()
-                .diaryID("diary777")
+                .diaryID("diary107")
                 .color("#123456")
                 .isActivated(true)
                 .userID("user1")
@@ -73,7 +73,7 @@ public class DiaryServiceTests {
     @Test
     public void testModifyPartner() {
 
-        diaryService.modifyPartner("diary103", "user77");
+        diaryService.modifyPartner("diary1", "user7");
 
     }
 

--- a/src/test/java/org/dallili/secretfriends/service/DiaryServiceTests.java
+++ b/src/test/java/org/dallili/secretfriends/service/DiaryServiceTests.java
@@ -27,26 +27,21 @@ public class DiaryServiceTests {
         //Optional<User> user = userRepository.findById("user1");
         //Optional<User> partner = userRepository.findById("user10");
 
-        /*DiaryDTO diaryDTO = DiaryDTO.builder()
-                .diaryID("diary103")
+        DiaryDTO diaryDTO = DiaryDTO.builder()
+                .diaryID("diary777")
                 .color("#123456")
                 .isActivated(true)
                 .userID("user1")
                 .partnerID("user10")
                 .updatedBy("user10")
                 .updatedAt(LocalDateTime.now())
-                .build();*/
-
-        DiaryDTO diaryDTO = DiaryDTO.builder()
-                .diaryID("diary103")
-                .userID("user1")
                 .build();
 
 
         log.info(diaryService.register(diaryDTO));
     }
 
-    /*
+
     @Test
     public void testReadOne() {
 
@@ -67,5 +62,25 @@ public class DiaryServiceTests {
         log.info("업데이트 할 것 : "+ diaryDTO);
 
         diaryService.update(diaryDTO);
-    }*/
+    }
+
+    @Test
+    public void testRemove() {
+
+        diaryService.remove("diary1");
+
+    }
+
+    @Test
+    public void testModifyPartner() {
+
+        diaryService.modifyPartner("diary103", "user77");
+
+    }
+
+    @Test
+    public void testModifyState() {
+
+        diaryService.modifyState("diary10");
+    }
 }

--- a/src/test/java/org/dallili/secretfriends/service/DiaryServiceTests.java
+++ b/src/test/java/org/dallili/secretfriends/service/DiaryServiceTests.java
@@ -12,7 +12,6 @@ import org.springframework.boot.test.context.SpringBootTest;
 import java.time.LocalDateTime;
 import java.util.Optional;
 
-@Transactional
 @SpringBootTest
 @Log4j2
 public class DiaryServiceTests {
@@ -25,22 +24,29 @@ public class DiaryServiceTests {
     @Test
     public void testRegister() {
 
-        Optional<User> user = userRepository.findById("user1");
-        Optional<User> partner = userRepository.findById("user10");
+        //Optional<User> user = userRepository.findById("user1");
+        //Optional<User> partner = userRepository.findById("user10");
 
-               DiaryDTO diaryDTO = DiaryDTO.builder()
-                .diaryID("diary101")
+        /*DiaryDTO diaryDTO = DiaryDTO.builder()
+                .diaryID("diary103")
                 .color("#123456")
                 .isActivated(true)
-                .user(user.orElseThrow())
-                .partner(partner.orElseThrow())
+                .userID("user1")
+                .partnerID("user10")
                 .updatedBy("user10")
                 .updatedAt(LocalDateTime.now())
-                        .build();
+                .build();*/
+
+        DiaryDTO diaryDTO = DiaryDTO.builder()
+                .diaryID("diary103")
+                .userID("user1")
+                .build();
+
 
         log.info(diaryService.register(diaryDTO));
     }
 
+    /*
     @Test
     public void testReadOne() {
 
@@ -48,4 +54,18 @@ public class DiaryServiceTests {
 
         log.info(diaryDTO);
     }
+
+    @Test
+    public void testUpdate() {
+
+        DiaryDTO diaryDTO = DiaryDTO.builder()
+                .diaryID("diary10")
+                .updatedAt(LocalDateTime.now())
+                .updatedBy("new user")
+                .build();
+
+        log.info("업데이트 할 것 : "+ diaryDTO);
+
+        diaryService.update(diaryDTO);
+    }*/
 }


### PR DESCRIPTION
## 작업 내용
- DiaryService의 CRUD 기능 작성 및 정상 작동 테스트 완료
- DiaryDTO <-> Diary의 원활한 매핑을 위한 modelmapper 설정
- Diary, User 엔티티 수정


## 구현 방법 
- RootConfig 파일에 PropertyMap 설정으로 DiaryDTO와 Diary의 어떤 필드가 매핑 되는지 명시

