### PR TITLE
[feat] 활성/비활성 일기장 조회 기능 구현

### DIFF
--- a/src/main/java/org/dallili/secretfriends/controller/DiaryController.java
+++ b/src/main/java/org/dallili/secretfriends/controller/DiaryController.java
@@ -11,6 +11,7 @@ import org.springframework.stereotype.Controller;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 
 import java.util.List;
 import java.util.stream.Collectors;
@@ -25,14 +26,13 @@ public class DiaryController {
     private final DiaryService diaryService;
 
     @Operation(summary = "Diary List GET", description = "활성/비활성 일기장 목록 조회")
-    @GetMapping(value = "/{state}")
-    public List<DiaryDTO> diaryDTOList (@PathVariable("state") Boolean state, String userID) {
-        List<DiaryDTO> diaries = diaryService.findAllDiaries()
-                .stream()
-                .filter(diaryDTO -> diaryDTO.isActivated() == state)
-                .filter(diaryDTO -> userID.equals(diaryDTO.getUserID()) || userID.equals(diaryDTO.getPartnerID()))
-                .collect(Collectors.toList());
-        log.info(state+ "상태인 일기장 목록: " + diaries);
+    @GetMapping(value = "/")
+    public List<DiaryDTO> diaryDTOList (@RequestParam("state") Boolean state, String userID) {
+
+        List<DiaryDTO> diaries = diaryService.findStateDiaries(userID, state);
+
+        log.info(state+ " 상태인 일기장 목록: " + diaries);
+
         return diaries;
     }
 

--- a/src/main/java/org/dallili/secretfriends/service/DiaryService.java
+++ b/src/main/java/org/dallili/secretfriends/service/DiaryService.java
@@ -16,6 +16,8 @@ public interface DiaryService {
 
     List<DiaryDTO> findAllDiaries();
 
+    List<DiaryDTO> findStateDiaries(String userID, Boolean state);
+
     void modifyPartner(String diaryID, String partnerID); // 일기장 파트너 결정
 
     void modifyState(String diaryID); // 일기장 비활성화

--- a/src/main/java/org/dallili/secretfriends/service/DiaryServiceImpl.java
+++ b/src/main/java/org/dallili/secretfriends/service/DiaryServiceImpl.java
@@ -121,4 +121,17 @@ public class DiaryServiceImpl implements DiaryService {
 
     }
 
+    @Override
+    public List<DiaryDTO> findStateDiaries(String userID, Boolean state) {
+
+        List<Diary> diaries = diaryRepository.findAll();
+
+        return diaries.stream()
+                .filter(diary -> diary.isActivated() == state)
+                .filter(diary -> userID.equals(diary.getUser().getUserID()) || userID.equals(diary.getPartner().getUserID()))
+                .map(diary -> modelMapper.map(diary, DiaryDTO.class) )
+                .collect(Collectors.toList());
+
+    }
+
 }

--- a/src/test/java/org/dallili/secretfriends/service/DiaryServiceTests.java
+++ b/src/test/java/org/dallili/secretfriends/service/DiaryServiceTests.java
@@ -10,6 +10,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 
 import java.time.LocalDateTime;
+import java.util.List;
 import java.util.Optional;
 
 @SpringBootTest
@@ -88,5 +89,13 @@ public class DiaryServiceTests {
 
         log.info(diaryService.findAllDiaries());
 
+    }
+
+    @Test
+    public void testFindStateDiaries(){
+
+        List<DiaryDTO> diaries = diaryService.findStateDiaries("user100", true);
+
+        log.info(diaries);
     }
 }


### PR DESCRIPTION
## 작업 내용
1. findAllDiaries() -> findStateDiaries()로 변경. 비즈니스 로직 diaryService로 이동
2. Path variable -> Query String으로 변경.


(이전 것보다 추가된 것은 많이 없으나 기능 별로 브랜치 나누려고 풀리퀘 작성함)

## 테스트 내역 

![image](https://github.com/Dallili/secretFriends-api/assets/99960721/40fed56b-a4e6-432e-97c3-fd8ca027e17b)

정상 작동...(진짜)
![image](https://github.com/Dallili/secretFriends-api/assets/99960721/056a84d4-05aa-4344-8f98-d44a37bbfac3)
