### PR TITLE
[Feat] 일기 조회 기능 구현

### DIFF
--- a/src/main/java/org/dallili/secretfriends/controller/EntryController.java
+++ b/src/main/java/org/dallili/secretfriends/controller/EntryController.java
@@ -12,6 +12,7 @@ import org.springframework.validation.BindingResult;
 import org.springframework.web.bind.annotation.*;
 
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 
 @RestController
@@ -51,5 +52,17 @@ public class EntryController {
             return Map.of("entryID",Long.toString(entryID),
                     "result","이미 전달된 일기");
 
+    }
+
+    @Operation(summary = "일기 조회", description = "특정 다이어리의 일기 목록 조회")
+    @GetMapping(value = "/list/{diaryID}")
+    public Map<String,Object> entryList(@PathVariable("diaryID") String diaryID){
+        List<EntryDTO.Response> entryDTO = entryService.findEntry(diaryID);
+
+        Map<String,Object> result = new HashMap<>();
+        result.put("total",entryDTO.size());
+        result.put("entries",entryDTO);
+
+        return result;
     }
 }

--- a/src/main/java/org/dallili/secretfriends/domain/Entry.java
+++ b/src/main/java/org/dallili/secretfriends/domain/Entry.java
@@ -38,8 +38,8 @@ public class Entry {
     @LastModifiedDate
     private LocalDateTime date;
 
-    @Column(name = "text", columnDefinition = "TEXT")
-    private String text;
+    @Column(name = "content", columnDefinition = "TEXT")
+    private String content;
 
     @Column(name = "sendAt", columnDefinition = "TIMESTAMP")
     private LocalDateTime sendAt;

--- a/src/main/java/org/dallili/secretfriends/domain/Entry.java
+++ b/src/main/java/org/dallili/secretfriends/domain/Entry.java
@@ -16,7 +16,7 @@ import java.time.LocalDateTime;
 @NoArgsConstructor
 @ToString(exclude = "diary")
 @Table(name = "entry", indexes = {
-        @Index(name="idx_entry_diary_diaryID", columnList = "diary_diaryID")
+        @Index(name="idx_entry_diary_diaryID", columnList = "diaryID")
 })
 @EntityListeners(value = {AuditingEntityListener.class})
 @DynamicInsert

--- a/src/main/java/org/dallili/secretfriends/dto/EntryDTO.java
+++ b/src/main/java/org/dallili/secretfriends/dto/EntryDTO.java
@@ -25,7 +25,7 @@ public class EntryDTO {
     @JsonFormat(pattern = "yyyy-MM-dd HH:mm:ss")
     private LocalDateTime date;
     @Size(min = 1, message = "일기 내용은 1자 이상 작성해야 한다.")
-    private String text;
+    private String content;
     @JsonFormat(pattern = "yyyy-MM-dd HH:mm:ss")
     private LocalDateTime sendAt;
     @Pattern(regexp = "[YN]", message = "state는 Y 혹은 N 값 중 하나여야 한다.")

--- a/src/main/java/org/dallili/secretfriends/dto/EntryDTO.java
+++ b/src/main/java/org/dallili/secretfriends/dto/EntryDTO.java
@@ -31,4 +31,15 @@ public class EntryDTO {
     @Pattern(regexp = "[YN]", message = "state는 Y 혹은 N 값 중 하나여야 한다.")
     private String state;
 
+    @Data
+    public static class Response{
+        private Long entryID;
+        @NotBlank
+        private String writer;
+        @JsonFormat(pattern = "yyyy-MM-dd HH:mm:ss")
+        private LocalDateTime date;
+        @Size(min = 1, message = "일기 내용은 1자 이상 작성해야 한다.")
+        private String content;
+    }
+
 }

--- a/src/main/java/org/dallili/secretfriends/repository/EntryRepository.java
+++ b/src/main/java/org/dallili/secretfriends/repository/EntryRepository.java
@@ -1,12 +1,14 @@
 package org.dallili.secretfriends.repository;
 
 import org.dallili.secretfriends.domain.Entry;
+import org.dallili.secretfriends.dto.EntryDTO;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
 import java.time.LocalDateTime;
+import java.util.List;
 
 public interface EntryRepository extends JpaRepository<Entry,Long> {
     @Modifying
@@ -16,5 +18,8 @@ public interface EntryRepository extends JpaRepository<Entry,Long> {
     @Modifying
     @Query("update Entry e set e.sendAt = :sendAt  where e.entryID = :entryID")
     int updateSendAt(@Param("entryID") Long eid, @Param("sendAt") LocalDateTime sendAt);
+
+    @Query("select e from Entry e where e.diary.diaryID = :diaryID")
+    List<Entry> selectEntry(@Param("diaryID") String diaryID);
 
 }

--- a/src/main/java/org/dallili/secretfriends/service/EntryService.java
+++ b/src/main/java/org/dallili/secretfriends/service/EntryService.java
@@ -3,8 +3,11 @@ package org.dallili.secretfriends.service;
 import jakarta.transaction.Transactional;
 import org.dallili.secretfriends.dto.EntryDTO;
 
+import java.util.List;
+
 @Transactional
 public interface EntryService {
     Long addEntry(EntryDTO entryDTO);
     Boolean modifyState(Long entryID);
+    List<EntryDTO.Response> findEntry(String diaryID);
 }

--- a/src/main/java/org/dallili/secretfriends/service/EntryServiceImpl.java
+++ b/src/main/java/org/dallili/secretfriends/service/EntryServiceImpl.java
@@ -10,7 +10,9 @@ import org.modelmapper.ModelMapper;
 import org.springframework.stereotype.Service;
 
 import java.time.LocalDateTime;
+import java.util.List;
 import java.util.Optional;
+import java.util.stream.Collectors;
 
 @Service
 @RequiredArgsConstructor
@@ -38,5 +40,15 @@ public class EntryServiceImpl implements EntryService {
             return true;
         } else
             return false;
+    }
+
+    @Override
+    public List<EntryDTO.Response> findEntry(String diaryID) {
+        List<Entry> entries = entryRepository.selectEntry(diaryID);
+
+        List<EntryDTO.Response> dto = entries.stream().map(entry -> modelMapper.map(entry,EntryDTO.Response.class)).collect(Collectors.toList());
+        dto.stream().forEach(entry->log.info(entry));
+
+        return dto;
     }
 }

--- a/src/test/java/org/dallili/secretfriends/repository/EntryRepositoryTests.java
+++ b/src/test/java/org/dallili/secretfriends/repository/EntryRepositoryTests.java
@@ -3,10 +3,12 @@ package org.dallili.secretfriends.repository;
 import lombok.extern.log4j.Log4j2;
 import org.dallili.secretfriends.domain.Diary;
 import org.dallili.secretfriends.domain.Entry;
+import org.dallili.secretfriends.dto.EntryDTO;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 
+import java.util.List;
 import java.util.stream.IntStream;
 
 @SpringBootTest
@@ -30,5 +32,15 @@ public class EntryRepositoryTests {
 
             entryRepository.save(entry);
         });
+    }
+
+    @Test
+    public void testSelectEntry(){
+        String diaryID = "diary1";
+
+        List<Entry> entries =  entryRepository.selectEntry(diaryID);
+
+        log.info(entries);
+
     }
 }

--- a/src/test/java/org/dallili/secretfriends/repository/EntryRepositoryTests.java
+++ b/src/test/java/org/dallili/secretfriends/repository/EntryRepositoryTests.java
@@ -25,7 +25,7 @@ public class EntryRepositoryTests {
             Entry entry = Entry.builder()
                     .diary(diary)
                     .writer(diary.getUser().getUserID())
-                    .text("일기 텍스트...")
+                    .content("일기 텍스트...")
                     .build();
 
             entryRepository.save(entry);

--- a/src/test/java/org/dallili/secretfriends/service/EntryServiceTests.java
+++ b/src/test/java/org/dallili/secretfriends/service/EntryServiceTests.java
@@ -6,6 +6,8 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 
+import java.util.List;
+
 @SpringBootTest
 @Log4j2
 public class EntryServiceTests {
@@ -34,4 +36,10 @@ public class EntryServiceTests {
         log.info(result);
     }
 
+    @Test
+    public void testFindEntry(){
+        String diaryID = "diary1";
+        List<EntryDTO.Response> dto = entryService.findEntry(diaryID);
+        dto.stream().forEach(i -> log.info(i));
+    }
 }

--- a/src/test/java/org/dallili/secretfriends/service/EntryServiceTests.java
+++ b/src/test/java/org/dallili/secretfriends/service/EntryServiceTests.java
@@ -19,7 +19,7 @@ public class EntryServiceTests {
         EntryDTO entryDTO = EntryDTO.builder()
                 .diaryID("diary1")
                 .writer("user1")
-                .text("일기")
+                .content("일기")
                 .build();
 
         Long eid = entryService.addEntry(entryDTO);


### PR DESCRIPTION
## 작업 내용
- 일기 조회 api 구현
- 테스트 코드 작성
## 구현 방법
- Entry 조회 응답용 dto 구현
- jpql 쿼리 메서드 작성
## 테스트 여부
- 정상 응답[1] 
  ![image](https://github.com/Dallili/secretFriends-api/assets/87927105/f750dab1-7834-41f4-85b7-74fdf8e868ca)
- 정상 응답[2] : 존재하지 않는 diary의 entity 조회 시
  ![image](https://github.com/Dallili/secretFriends-api/assets/87927105/49f6c8a5-61d7-4af0-aa4e-4102078f5111)

