### PR TITLE
[Feat] 일기 수정 기능 구현

### DIFF
--- a/src/main/java/org/dallili/secretfriends/controller/EntryController.java
+++ b/src/main/java/org/dallili/secretfriends/controller/EntryController.java
@@ -41,6 +41,21 @@ public class EntryController {
 
     }
 
+    @Operation(summary = "일기 수정", description = "전달되지 않은 일기의 content 필드 값 업데이트")
+    @PutMapping(value = "/{entryID}")
+    public EntryDTO.Response contentModify(@Valid @RequestBody EntryDTO.ModifyRequest request, BindingResult bindingResult) throws BindException{
+
+        log.info(request);
+        if(bindingResult.hasErrors()){
+            throw new BindException(bindingResult);
+        }
+
+        EntryDTO.Response response = entryService.modifyContent(request);
+        log.info(response);
+
+        return response;
+    }
+
     @Operation(summary = "일기 전달", description = "저장된 일기의 state, sendAt 필드 값 업데이트")
     @PatchMapping(value = "/{entryID}")
     public Map<String,String> stateModify(@PathVariable("entryID") Long entryID){

--- a/src/main/java/org/dallili/secretfriends/domain/Entry.java
+++ b/src/main/java/org/dallili/secretfriends/domain/Entry.java
@@ -49,6 +49,10 @@ public class Entry {
     @Builder.Default
     private String state = "N";
 
+    public void changeContent(String content){
+        this.content = content;
+    }
+
     @PrePersist
     public void defaultState(){
         if(this.state == null) {

--- a/src/main/java/org/dallili/secretfriends/domain/Entry.java
+++ b/src/main/java/org/dallili/secretfriends/domain/Entry.java
@@ -60,4 +60,11 @@ public class Entry {
         }
     }
 
+    @PreUpdate
+    public void preventUpdate(){
+        if(this.state.equals("Y")){
+            throw new IllegalStateException("전달된 일기는 내용 수정 불가");
+        }
+    }
+
 }

--- a/src/main/java/org/dallili/secretfriends/dto/EntryDTO.java
+++ b/src/main/java/org/dallili/secretfriends/dto/EntryDTO.java
@@ -32,6 +32,14 @@ public class EntryDTO {
     private String state;
 
     @Data
+    @Builder
+    public static class ModifyRequest{
+        private Long entryID;
+        @Size(min = 1, message = "일기 내용은 1자 이상 작성해야 한다.")
+        private String content;
+    }
+
+    @Data
     public static class Response{
         private Long entryID;
         @NotBlank

--- a/src/main/java/org/dallili/secretfriends/service/EntryService.java
+++ b/src/main/java/org/dallili/secretfriends/service/EntryService.java
@@ -9,5 +9,6 @@ import java.util.List;
 public interface EntryService {
     Long addEntry(EntryDTO entryDTO);
     Boolean modifyState(Long entryID);
+    EntryDTO.Response modifyContent(EntryDTO.ModifyRequest entryDTO);
     List<EntryDTO.Response> findEntry(String diaryID);
 }

--- a/src/main/java/org/dallili/secretfriends/service/EntryServiceImpl.java
+++ b/src/main/java/org/dallili/secretfriends/service/EntryServiceImpl.java
@@ -43,6 +43,19 @@ public class EntryServiceImpl implements EntryService {
     }
 
     @Override
+    public EntryDTO.Response modifyContent(EntryDTO.ModifyRequest entryDTO) {
+        Optional<Entry> entryOptional = entryRepository.findById(entryDTO.getEntryID());
+        Entry entry = entryOptional.orElseThrow();
+
+        entry.changeContent(entryDTO.getContent());
+        entryRepository.save(entry);
+        entryRepository.flush();
+
+        EntryDTO.Response response = modelMapper.map(entry,EntryDTO.Response.class);
+        return response;
+    }
+
+    @Override
     public List<EntryDTO.Response> findEntry(String diaryID) {
         List<Entry> entries = entryRepository.selectEntry(diaryID);
 

--- a/src/test/java/org/dallili/secretfriends/service/EntryServiceTests.java
+++ b/src/test/java/org/dallili/secretfriends/service/EntryServiceTests.java
@@ -30,6 +30,16 @@ public class EntryServiceTests {
     }
 
     @Test
+    public void testModifyContent(){
+        EntryDTO.ModifyRequest req = EntryDTO.ModifyRequest.builder()
+                .entryID(8L)
+                .content("수정된 일기")
+                .build();
+        EntryDTO.Response res = entryService.modifyContent(req);
+        log.info(res);
+    }
+
+    @Test
     public void testModifyState(){
         Long eid = 1L;
         Boolean result = entryService.modifyState(eid);


### PR DESCRIPTION
## 작업 내용
- 일기 수정 api 구현
- 테스트 코드 작성

## 구현 방법 
- EntryDTO 요청용 dto 작성

## 테스트 여부
- 정상 응답
  <img width="780" alt="image" src="https://github.com/Dallili/secretFriends-api/assets/87927105/ffbcd40d-2d17-4aaf-ac32-34d60627c91c">

- 500 Internal Server Error : entryID 값이 존재하지 않음
  <img width="779" alt="image" src="https://github.com/Dallili/secretFriends-api/assets/87927105/412a5149-a176-413c-84d5-ae4e0aec9f31">

- 400 Bad Request : content 값이 blank 
  <img width="782" alt="image" src="https://github.com/Dallili/secretFriends-api/assets/87927105/44fb8e60-49c9-44d5-9788-e6a6293402b7">

