### PR TITLE
[Refactor] 일기 조회 api 응답 포맷 변경

### DIFF
--- a/src/main/java/org/dallili/secretfriends/controller/EntryController.java
+++ b/src/main/java/org/dallili/secretfriends/controller/EntryController.java
@@ -43,14 +43,14 @@ public class EntryController {
 
     @Operation(summary = "일기 수정", description = "전달되지 않은 일기의 content 필드 값 업데이트")
     @PutMapping(value = "/{entryID}")
-    public EntryDTO.Response contentModify(@Valid @RequestBody EntryDTO.ModifyRequest request, BindingResult bindingResult) throws BindException{
+    public EntryDTO.UnsentEntryResponse contentModify(@Valid @RequestBody EntryDTO.ModifyRequest request, BindingResult bindingResult) throws BindException{
 
         log.info(request);
         if(bindingResult.hasErrors()){
             throw new BindException(bindingResult);
         }
 
-        EntryDTO.Response response = entryService.modifyContent(request);
+        EntryDTO.UnsentEntryResponse response = entryService.modifyContent(request);
         log.info(response);
 
         return response;
@@ -72,11 +72,13 @@ public class EntryController {
     @Operation(summary = "일기 조회", description = "특정 다이어리의 일기 목록 조회")
     @GetMapping(value = "/list/{diaryID}")
     public Map<String,Object> entryList(@PathVariable("diaryID") String diaryID){
-        List<EntryDTO.Response> entryDTO = entryService.findEntry(diaryID);
+        List<EntryDTO.SentEntryResponse> SentEntry = entryService.findSentEntry(diaryID);
+        List<EntryDTO.UnsentEntryResponse> UnsentEntry = entryService.findUnsentEntry(diaryID);
 
         Map<String,Object> result = new HashMap<>();
-        result.put("total",entryDTO.size());
-        result.put("entries",entryDTO);
+        result.put("total",SentEntry.size());
+        result.put("sent",SentEntry);
+        result.put("unsent",UnsentEntry);
 
         return result;
     }

--- a/src/main/java/org/dallili/secretfriends/dto/EntryDTO.java
+++ b/src/main/java/org/dallili/secretfriends/dto/EntryDTO.java
@@ -40,12 +40,23 @@ public class EntryDTO {
     }
 
     @Data
-    public static class Response{
+    public static class UnsentEntryResponse{
         private Long entryID;
         @NotBlank
         private String writer;
         @JsonFormat(pattern = "yyyy-MM-dd HH:mm:ss")
         private LocalDateTime date;
+        @Size(min = 1, message = "일기 내용은 1자 이상 작성해야 한다.")
+        private String content;
+    }
+
+    @Data
+    public static class SentEntryResponse{
+        private Long entryID;
+        @NotBlank
+        private String writer;
+        @JsonFormat(pattern = "yyyy-MM-dd HH:mm:ss")
+        private LocalDateTime sendAt;
         @Size(min = 1, message = "일기 내용은 1자 이상 작성해야 한다.")
         private String content;
     }

--- a/src/main/java/org/dallili/secretfriends/repository/EntryRepository.java
+++ b/src/main/java/org/dallili/secretfriends/repository/EntryRepository.java
@@ -19,7 +19,7 @@ public interface EntryRepository extends JpaRepository<Entry,Long> {
     @Query("update Entry e set e.sendAt = :sendAt  where e.entryID = :entryID")
     int updateSendAt(@Param("entryID") Long eid, @Param("sendAt") LocalDateTime sendAt);
 
-    @Query("select e from Entry e where e.diary.diaryID = :diaryID")
-    List<Entry> selectEntry(@Param("diaryID") String diaryID);
+    @Query("select e from Entry e where e.diary.diaryID = :diaryID and e.state = :state")
+    List<Entry> selectEntry(@Param("diaryID") String diaryID, @Param("state") String state);
 
 }

--- a/src/main/java/org/dallili/secretfriends/service/EntryService.java
+++ b/src/main/java/org/dallili/secretfriends/service/EntryService.java
@@ -9,6 +9,7 @@ import java.util.List;
 public interface EntryService {
     Long addEntry(EntryDTO entryDTO);
     Boolean modifyState(Long entryID);
-    EntryDTO.Response modifyContent(EntryDTO.ModifyRequest entryDTO);
-    List<EntryDTO.Response> findEntry(String diaryID);
+    EntryDTO.UnsentEntryResponse modifyContent(EntryDTO.ModifyRequest entryDTO);
+    List<EntryDTO.SentEntryResponse> findSentEntry(String diaryID);
+    List<EntryDTO.UnsentEntryResponse> findUnsentEntry(String diaryID);
 }

--- a/src/main/java/org/dallili/secretfriends/service/EntryServiceImpl.java
+++ b/src/main/java/org/dallili/secretfriends/service/EntryServiceImpl.java
@@ -43,7 +43,7 @@ public class EntryServiceImpl implements EntryService {
     }
 
     @Override
-    public EntryDTO.Response modifyContent(EntryDTO.ModifyRequest entryDTO) {
+    public EntryDTO.UnsentEntryResponse modifyContent(EntryDTO.ModifyRequest entryDTO) {
         Optional<Entry> entryOptional = entryRepository.findById(entryDTO.getEntryID());
         Entry entry = entryOptional.orElseThrow();
 
@@ -51,16 +51,24 @@ public class EntryServiceImpl implements EntryService {
         entryRepository.save(entry);
         entryRepository.flush();
 
-        EntryDTO.Response response = modelMapper.map(entry,EntryDTO.Response.class);
+        EntryDTO.UnsentEntryResponse response = modelMapper.map(entry,EntryDTO.UnsentEntryResponse.class);
         return response;
     }
 
     @Override
-    public List<EntryDTO.Response> findEntry(String diaryID) {
-        List<Entry> entries = entryRepository.selectEntry(diaryID);
+    public List<EntryDTO.SentEntryResponse> findSentEntry(String diaryID) {
+        List<Entry> entries = entryRepository.selectEntry(diaryID,"Y");
 
-        List<EntryDTO.Response> dto = entries.stream().map(entry -> modelMapper.map(entry,EntryDTO.Response.class)).collect(Collectors.toList());
-        dto.stream().forEach(entry->log.info(entry));
+        List<EntryDTO.SentEntryResponse> dto = entries.stream().map(entry -> modelMapper.map(entry,EntryDTO.SentEntryResponse.class)).collect(Collectors.toList());
+
+        return dto;
+    }
+
+    @Override
+    public List<EntryDTO.UnsentEntryResponse> findUnsentEntry(String diaryID) {
+        List<Entry> entries = entryRepository.selectEntry(diaryID,"N");
+
+        List<EntryDTO.UnsentEntryResponse> dto = entries.stream().map(entry -> modelMapper.map(entry,EntryDTO.UnsentEntryResponse.class)).collect(Collectors.toList());
 
         return dto;
     }

--- a/src/test/java/org/dallili/secretfriends/repository/EntryRepositoryTests.java
+++ b/src/test/java/org/dallili/secretfriends/repository/EntryRepositoryTests.java
@@ -38,7 +38,7 @@ public class EntryRepositoryTests {
     public void testSelectEntry(){
         String diaryID = "diary1";
 
-        List<Entry> entries =  entryRepository.selectEntry(diaryID);
+        List<Entry> entries =  entryRepository.selectEntry(diaryID,"Y");
 
         log.info(entries);
 

--- a/src/test/java/org/dallili/secretfriends/service/EntryServiceTests.java
+++ b/src/test/java/org/dallili/secretfriends/service/EntryServiceTests.java
@@ -32,24 +32,30 @@ public class EntryServiceTests {
     @Test
     public void testModifyContent(){
         EntryDTO.ModifyRequest req = EntryDTO.ModifyRequest.builder()
-                .entryID(8L)
+                .entryID(11L)
                 .content("수정된 일기")
                 .build();
-        EntryDTO.Response res = entryService.modifyContent(req);
+        EntryDTO.UnsentEntryResponse res = entryService.modifyContent(req);
         log.info(res);
     }
 
     @Test
     public void testModifyState(){
-        Long eid = 1L;
+        Long eid = 12L;
         Boolean result = entryService.modifyState(eid);
         log.info(result);
     }
 
     @Test
-    public void testFindEntry(){
+    public void testFindSentEntry(){
         String diaryID = "diary1";
-        List<EntryDTO.Response> dto = entryService.findEntry(diaryID);
+        List<EntryDTO.SentEntryResponse> dto = entryService.findSentEntry(diaryID);
+        dto.stream().forEach(i -> log.info(i));
+    }
+    @Test
+    public void testFindUnsentEntry(){
+        String diaryID = "diary1";
+        List<EntryDTO.UnsentEntryResponse> dto = entryService.findUnsentEntry(diaryID);
         dto.stream().forEach(i -> log.info(i));
     }
 }


### PR DESCRIPTION
## 작업 내용

- 일기 조회 api 응답 포맷 변경
- 기존 응답: 일기 데이터 한꺼번에 전송
```json
{
  "total": 3,
  "entries": [
    {
      "entryID": 11,
      "writer": "user1",
      "date": "2024-03-31 00:26:58",
      "content": "수정된 일기"
    },
    {
      "entryID": 12,
      "writer": "user1",
      "date": "2024-03-31 00:27:22",
      "content": "일기 텍스트..."
    },
    {
      "entryID": 13,
      "writer": "user1",
      "date": "2024-03-31 16:08:34",
      "content": "일기 텍스트..."
    }
  ]
}
```

- 변경 후 응답: 전달된 일기(sent)와 전달되지 않은(unsent) 일기 구분
```json
{
  "total": 2,
  "unsent": [
    {
      "entryID": 13,
      "writer": "user1",
      "date": "2024-03-27 16:08:34",
      "content": "일기 텍스트..."
    }
  ],
  "sent": [
    {
      "entryID": 11,
      "writer": "user1",
      "sendAt": "2024-03-31 00:26:58",
      "content": "수정된 일기"
    },
    {
      "entryID": 12,
      "writer": "user1",
      "sendAt": "2024-03-31 00:27:22",
      "content": "일기 텍스트..."
    }
  ]
}
```

## 구현 방법

- Entry Response DTO 를 sent와 unsent 로 분리

