### PR TITLE
[feat] 매칭 관련 기본 작업 / 초대 코드 조회 기능 

### DIFF
--- a/src/main/java/org/dallili/secretfriends/controller/DiaryController.java
+++ b/src/main/java/org/dallili/secretfriends/controller/DiaryController.java
@@ -10,11 +10,14 @@ import org.dallili.secretfriends.repository.DiaryRepository;
 import org.dallili.secretfriends.service.DiaryService;
 import org.springframework.http.MediaType;
 import org.springframework.stereotype.Controller;
+import org.springframework.validation.BindException;
+import org.springframework.validation.BindingResult;
 import org.springframework.web.bind.annotation.*;
 
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.UUID;
 import java.util.stream.Collectors;
 
 @RestController
@@ -40,6 +43,24 @@ public class DiaryController {
 
         return result;
     }
+
+    @Operation(summary = "Register Diary POST", description = "일기장 등록")
+    @PostMapping(value = "/", consumes = MediaType.APPLICATION_JSON_VALUE)
+    public Map<String, UUID> diaryAdd(@Valid @RequestBody DiaryDTO diaryDTO, BindingResult bindingResult) throws BindException {
+
+        if(bindingResult.hasErrors()){
+            throw new BindException(bindingResult);
+        }
+
+        Map<String, UUID> result = new HashMap<>();
+
+        UUID diaryID = diaryService.addDiary(diaryDTO);
+        result.put("diaryID", diaryID);
+
+        return result;
+
+    }
+
 
     @Operation(summary = "Diary Deactivate PATCH", description = "일기장 비활성화")
     @PatchMapping(value = "/{diaryID}/isActivated")

--- a/src/main/java/org/dallili/secretfriends/controller/MatchingController.java
+++ b/src/main/java/org/dallili/secretfriends/controller/MatchingController.java
@@ -1,0 +1,33 @@
+package org.dallili.secretfriends.controller;
+
+import io.swagger.v3.oas.annotations.Operation;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.log4j.Log4j2;
+import org.dallili.secretfriends.dto.DiaryDTO;
+import org.dallili.secretfriends.repository.DiaryRepository;
+import org.dallili.secretfriends.service.DiaryService;
+import org.dallili.secretfriends.service.MatchingHistoryService;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@Log4j2
+@RequiredArgsConstructor
+@RequestMapping("/matches")
+public class MatchingController {
+
+    final MatchingHistoryService matchingHistoryService;
+
+    final DiaryService diaryService;
+
+
+    @Operation(summary = "Get Code GET", description = "초대 코드 리턴")
+    @GetMapping(value = "/{diaryID}")
+    public String codeDetails(String diaryID){
+
+        String code = diaryService.findOne(diaryID).getDiaryID();
+
+        return code;
+    }
+}

--- a/src/main/java/org/dallili/secretfriends/domain/Diary.java
+++ b/src/main/java/org/dallili/secretfriends/domain/Diary.java
@@ -27,8 +27,8 @@ public class Diary{
     @JoinColumn(name = "partnerID", referencedColumnName = "userID", insertable = true, updatable = true)
     private User partner;
 
-    @Column(name = "isActivated",columnDefinition = "TINYINT")
-    private boolean isActivated;
+    @Column(name = "state",columnDefinition = "TINYINT")
+    private boolean state;
 
     @Column(name = "updatedBy", length = 20)
     private String updatedBy;
@@ -49,7 +49,7 @@ public class Diary{
     }
 
     public void changeState(Boolean state){
-        this.isActivated = state;
+        this.state = state;
     }
 
 

--- a/src/main/java/org/dallili/secretfriends/domain/Diary.java
+++ b/src/main/java/org/dallili/secretfriends/domain/Diary.java
@@ -3,10 +3,12 @@ package org.dallili.secretfriends.domain;
 import lombok.*;
 import jakarta.persistence.*;
 import org.hibernate.annotations.ColumnDefault;
+import org.hibernate.annotations.GenericGenerator;
 import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 
 import java.sql.Timestamp;
 import java.time.LocalDateTime;
+import java.util.UUID;
 
 //엔티티 객체를 위한 엔티티 클래스는 반드시 @Entity를 적용해야하고 @Id가 필요하다
 @Entity
@@ -20,8 +22,10 @@ import java.time.LocalDateTime;
 public class Diary{
 
     @Id
-    @Column(name = "diaryID", length = 20)
-    private String diaryID;
+    @GeneratedValue(generator = "uuid2")
+    @GenericGenerator(name="uuid2", strategy = "uuid2")
+    @Column(name = "diaryID", columnDefinition = "VARBINARY(36)")
+    private UUID diaryID;
 
     @ManyToOne(fetch = FetchType.LAZY) //여러 개의 diary가 하나의 user에 속할 수 있음
     @JoinColumn(name = "userID", referencedColumnName = "userID", insertable = true, updatable = false)

--- a/src/main/java/org/dallili/secretfriends/domain/Diary.java
+++ b/src/main/java/org/dallili/secretfriends/domain/Diary.java
@@ -2,6 +2,9 @@ package org.dallili.secretfriends.domain;
 
 import lombok.*;
 import jakarta.persistence.*;
+import org.hibernate.annotations.ColumnDefault;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
 import java.sql.Timestamp;
 import java.time.LocalDateTime;
 
@@ -12,6 +15,7 @@ import java.time.LocalDateTime;
 @AllArgsConstructor
 @NoArgsConstructor
 @ToString(exclude = {"user","partner"})
+@EntityListeners(value = {AuditingEntityListener.class})
 @Table (name = "diary")
 public class Diary{
 
@@ -38,6 +42,11 @@ public class Diary{
 
     @Column(name = "color", length = 7)
     private String color;
+
+    @PrePersist
+    public void prePersist() {
+        this.state = true;
+    }
 
     public void updateDiary(String updatedBy, LocalDateTime updatedAt){
         this.updatedBy = updatedBy;

--- a/src/main/java/org/dallili/secretfriends/domain/Interest.java
+++ b/src/main/java/org/dallili/secretfriends/domain/Interest.java
@@ -1,0 +1,23 @@
+package org.dallili.secretfriends.domain;
+
+import jakarta.persistence.*;
+import lombok.*;
+
+@Entity
+@Getter
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor
+@ToString
+@Table(name = "interest")
+public class Interest {
+
+    @Id
+    @Column(name = "interestID")
+    //@GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long interestID;
+
+    @Column(name = "type", length = 20)
+    private String type;
+
+}

--- a/src/main/java/org/dallili/secretfriends/domain/Interest.java
+++ b/src/main/java/org/dallili/secretfriends/domain/Interest.java
@@ -14,7 +14,7 @@ public class Interest {
 
     @Id
     @Column(name = "interestID")
-    //@GeneratedValue(strategy = GenerationType.IDENTITY)
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long interestID;
 
     @Column(name = "type", length = 20)

--- a/src/main/java/org/dallili/secretfriends/domain/Matching.java
+++ b/src/main/java/org/dallili/secretfriends/domain/Matching.java
@@ -1,0 +1,39 @@
+package org.dallili.secretfriends.domain;
+
+import jakarta.persistence.*;
+import lombok.*;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Getter
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor
+@ToString
+@Table(name = "matching")
+public class Matching {
+
+    @Id
+    @Column(name = "matchingID")
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long matchingID;
+
+    @JoinColumn(name = "userID", referencedColumnName = "userID", insertable = true, updatable = true)
+    private String userID;
+
+    @Column(name = "createdAt", columnDefinition = "TIMESTAMP")
+    private LocalDateTime createdAt;
+
+    @JoinColumn(name = "firstInterest", referencedColumnName = "interestID", insertable = true, updatable = true)
+    private Long firstInterest;
+
+    @JoinColumn(name = "secondInterest", referencedColumnName = "interestID", insertable = true, updatable = true)
+    private Long secondInterest;
+
+    @JoinColumn(name = "thirdInterest", referencedColumnName = "interestID", insertable = true, updatable = true)
+    private Long thirdInterest;
+
+
+
+}

--- a/src/main/java/org/dallili/secretfriends/domain/MatchingHistory.java
+++ b/src/main/java/org/dallili/secretfriends/domain/MatchingHistory.java
@@ -1,0 +1,28 @@
+package org.dallili.secretfriends.domain;
+
+import jakarta.persistence.*;
+import lombok.*;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Getter
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor
+@ToString
+@Table(name = "matchingHistory")
+public class MatchingHistory {
+
+    @Id
+    @Column(name = "historyID")
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long historyID;
+
+    @JoinColumn(name = "userID", referencedColumnName = "userID", insertable = true, updatable = true)
+    private String userID;
+
+    @JoinColumn(name = "partnerID", referencedColumnName = "userID", insertable = true, updatable = true)
+    private String partnerID;
+
+}

--- a/src/main/java/org/dallili/secretfriends/dto/DiaryDTO.java
+++ b/src/main/java/org/dallili/secretfriends/dto/DiaryDTO.java
@@ -19,7 +19,6 @@ import java.time.LocalDateTime;
 
 public class DiaryDTO {
 
-    @NotNull
     private String diaryID; //get
 
     @NotEmpty

--- a/src/main/java/org/dallili/secretfriends/dto/DiaryDTO.java
+++ b/src/main/java/org/dallili/secretfriends/dto/DiaryDTO.java
@@ -27,7 +27,7 @@ public class DiaryDTO {
 
     private String partnerID; //get, set
 
-    private boolean isActivated; //get, set
+    private boolean state; //get, set
 
     private String updatedBy; //get. set
 

--- a/src/main/java/org/dallili/secretfriends/dto/MatchingHistoryDTO.java
+++ b/src/main/java/org/dallili/secretfriends/dto/MatchingHistoryDTO.java
@@ -1,0 +1,22 @@
+package org.dallili.secretfriends.dto;
+
+import jakarta.persistence.*;
+import jakarta.validation.constraints.NotBlank;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor
+public class MatchingHistoryDTO {
+
+    @NotBlank
+    private Long historyID;
+    @NotBlank
+    private String userID;
+    @NotBlank
+    private String partnerID;
+}

--- a/src/main/java/org/dallili/secretfriends/repository/InterestRepository.java
+++ b/src/main/java/org/dallili/secretfriends/repository/InterestRepository.java
@@ -1,0 +1,7 @@
+package org.dallili.secretfriends.repository;
+
+import org.dallili.secretfriends.domain.Interest;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface InterestRepository extends JpaRepository<Interest, Long> {
+}

--- a/src/main/java/org/dallili/secretfriends/repository/MatchingHistoryRepository.java
+++ b/src/main/java/org/dallili/secretfriends/repository/MatchingHistoryRepository.java
@@ -1,0 +1,7 @@
+package org.dallili.secretfriends.repository;
+
+import org.dallili.secretfriends.domain.MatchingHistory;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface MatchingHistoryRepository extends JpaRepository<MatchingHistory, Long> {
+}

--- a/src/main/java/org/dallili/secretfriends/repository/MatchingRepository.java
+++ b/src/main/java/org/dallili/secretfriends/repository/MatchingRepository.java
@@ -1,0 +1,7 @@
+package org.dallili.secretfriends.repository;
+
+import org.dallili.secretfriends.domain.Matching;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface MatchingRepository extends JpaRepository<Matching, Long> {
+}

--- a/src/main/java/org/dallili/secretfriends/service/DiaryService.java
+++ b/src/main/java/org/dallili/secretfriends/service/DiaryService.java
@@ -4,9 +4,11 @@ import org.dallili.secretfriends.domain.Diary;
 import org.dallili.secretfriends.dto.DiaryDTO;
 
 import java.util.List;
+import java.util.UUID;
+
 public interface DiaryService {
 
-    String addDiary(DiaryDTO diaryDTO); // 일기장 등록
+    UUID addDiary(DiaryDTO diaryDTO); // 일기장 등록
 
     DiaryDTO findOne(String diaryID); // 일기장 조회
 

--- a/src/main/java/org/dallili/secretfriends/service/DiaryServiceImpl.java
+++ b/src/main/java/org/dallili/secretfriends/service/DiaryServiceImpl.java
@@ -142,6 +142,7 @@ public class DiaryServiceImpl implements DiaryService {
         return diaries.stream()
                 .filter(diary -> diary.isState() == true)
                 .filter(diary -> loginUserID.equals(diary.getUser().getUserID()) || loginUserID.equals(diary.getPartner().getUserID()))
+                .filter(diary -> diary.getUpdatedBy()!=null)
                 .filter(diary -> !loginUserID.equals(diary.getUpdatedBy()))
                 .map(diary -> modelMapper.map(diary, DiaryDTO.class))
                 .collect(Collectors.toList());

--- a/src/main/java/org/dallili/secretfriends/service/DiaryServiceImpl.java
+++ b/src/main/java/org/dallili/secretfriends/service/DiaryServiceImpl.java
@@ -127,7 +127,7 @@ public class DiaryServiceImpl implements DiaryService {
         List<Diary> diaries = diaryRepository.findAll();
 
         return diaries.stream()
-                .filter(diary -> diary.isActivated() == state)
+                .filter(diary -> diary.isState() == state)
                 .filter(diary -> userID.equals(diary.getUser().getUserID()) || userID.equals(diary.getPartner().getUserID()))
                 .map(diary -> modelMapper.map(diary, DiaryDTO.class) )
                 .collect(Collectors.toList());
@@ -140,7 +140,7 @@ public class DiaryServiceImpl implements DiaryService {
         List<Diary> diaries = diaryRepository.findAll();
 
         return diaries.stream()
-                .filter(diary -> diary.isActivated() == true)
+                .filter(diary -> diary.isState() == true)
                 .filter(diary -> loginUserID.equals(diary.getUser().getUserID()) || loginUserID.equals(diary.getPartner().getUserID()))
                 .filter(diary -> !loginUserID.equals(diary.getUpdatedBy()))
                 .map(diary -> modelMapper.map(diary, DiaryDTO.class))

--- a/src/main/java/org/dallili/secretfriends/service/DiaryServiceImpl.java
+++ b/src/main/java/org/dallili/secretfriends/service/DiaryServiceImpl.java
@@ -15,6 +15,7 @@ import org.springframework.stereotype.Service;
 import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Optional;
+import java.util.UUID;
 import java.util.stream.Collectors;
 
 @Service
@@ -29,11 +30,11 @@ public class DiaryServiceImpl implements DiaryService {
     private final UserRepository userRepository;
 
     @Override
-    public String addDiary(DiaryDTO diaryDTO) {
+    public UUID addDiary(DiaryDTO diaryDTO) {
 
         Diary diary = modelMapper.map(diaryDTO, Diary.class);
 
-        String diaryID = diaryRepository.save(diary).getDiaryID();
+        UUID diaryID = diaryRepository.save(diary).getDiaryID();
 
         return diaryID;
     }

--- a/src/main/java/org/dallili/secretfriends/service/MatchingHistoryService.java
+++ b/src/main/java/org/dallili/secretfriends/service/MatchingHistoryService.java
@@ -1,0 +1,12 @@
+package org.dallili.secretfriends.service;
+
+import jakarta.transaction.Transactional;
+import org.dallili.secretfriends.dto.DiaryDTO;
+import org.dallili.secretfriends.domain.MatchingHistory;
+
+@Transactional
+public interface MatchingHistoryService {
+
+    Long addHistory(String userID, String partnerID);
+
+}

--- a/src/main/java/org/dallili/secretfriends/service/MatchingHistoryServiceImpl.java
+++ b/src/main/java/org/dallili/secretfriends/service/MatchingHistoryServiceImpl.java
@@ -1,0 +1,36 @@
+package org.dallili.secretfriends.service;
+
+import jakarta.transaction.Transactional;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.log4j.Log4j2;
+import org.dallili.secretfriends.domain.MatchingHistory;
+import org.dallili.secretfriends.dto.MatchingHistoryDTO;
+import org.dallili.secretfriends.repository.MatchingHistoryRepository;
+import org.modelmapper.ModelMapper;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+@Log4j2
+@Transactional
+public class MatchingHistoryServiceImpl implements MatchingHistoryService{
+
+    final MatchingHistoryRepository matchingHistoryRepository;
+
+    final ModelMapper modelMapper;
+
+    @Override
+    public Long addHistory(String userID, String partnerID){
+
+        MatchingHistoryDTO matchingHistoryDTO = MatchingHistoryDTO.builder()
+                .userID(userID)
+                .partnerID(partnerID)
+                .build();
+
+        MatchingHistory matchingHistory = modelMapper.map(matchingHistoryDTO, MatchingHistory.class);
+
+        matchingHistoryRepository.save(matchingHistory);
+
+        return matchingHistory.getHistoryID();
+    }
+}

--- a/src/test/java/org/dallili/secretfriends/repository/DiaryRepositoryTests.java
+++ b/src/test/java/org/dallili/secretfriends/repository/DiaryRepositoryTests.java
@@ -31,7 +31,7 @@ public class DiaryRepositoryTests {
                     .diaryID("diary"+i)
                     .user(user.orElseThrow())
                     .partner(partner.orElseThrow())
-                    .isActivated(i%2==0?true:false)
+                    .state(i%2==0?true:false)
                     .updatedBy(user.orElseThrow().getUserID())
                     .updatedAt(LocalDateTime.now())
                     .color("#000000")

--- a/src/test/java/org/dallili/secretfriends/repository/DiaryRepositoryTests.java
+++ b/src/test/java/org/dallili/secretfriends/repository/DiaryRepositoryTests.java
@@ -28,12 +28,27 @@ public class DiaryRepositoryTests {
             Optional<User> partner = userRepository.findById("user"+((i+1)%100+1));
 
             Diary diary = Diary.builder()
-                    .diaryID("diary"+i)
                     .user(user.orElseThrow())
                     .partner(partner.orElseThrow())
                     .state(i%2==0?true:false)
                     .updatedBy(user.orElseThrow().getUserID())
                     .updatedAt(LocalDateTime.now())
+                    .color("#000000")
+                    .build();
+
+            diaryRepository.save(diary);
+
+        });
+    }
+
+    @Test
+    public void testKeyGenerate(){
+        IntStream.rangeClosed(1,10).forEach(i->{
+
+            Optional<User> user = userRepository.findById("user"+i);
+
+            Diary diary = Diary.builder()
+                    .user(user.orElseThrow())
                     .color("#000000")
                     .build();
 
@@ -50,7 +65,6 @@ public class DiaryRepositoryTests {
             Optional<User> partner = userRepository.findById("user2");
 
             Diary diary = Diary.builder()
-                    .diaryID("diary"+i)
                     .user(user.orElseThrow())
                     .partner(partner.orElseThrow())
                     .state(i%2==0?true:false)

--- a/src/test/java/org/dallili/secretfriends/repository/DiaryRepositoryTests.java
+++ b/src/test/java/org/dallili/secretfriends/repository/DiaryRepositoryTests.java
@@ -42,4 +42,24 @@ public class DiaryRepositoryTests {
         });
     }
 
+    @Test
+    public void testInsertBlankDiary(){
+        IntStream.rangeClosed(100,110).forEach(i->{
+
+            Optional<User> user = userRepository.findById("user1");
+            Optional<User> partner = userRepository.findById("user2");
+
+            Diary diary = Diary.builder()
+                    .diaryID("diary"+i)
+                    .user(user.orElseThrow())
+                    .partner(partner.orElseThrow())
+                    .state(i%2==0?true:false)
+                    .color("#000000")
+                    .build();
+
+            diaryRepository.save(diary);
+
+        });
+    }
+
 }

--- a/src/test/java/org/dallili/secretfriends/repository/InterestRepositoryTests.java
+++ b/src/test/java/org/dallili/secretfriends/repository/InterestRepositoryTests.java
@@ -1,0 +1,29 @@
+package org.dallili.secretfriends.repository;
+
+import lombok.extern.log4j.Log4j2;
+import org.dallili.secretfriends.domain.Interest;
+import org.dallili.secretfriends.domain.User;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+
+import java.time.LocalDate;
+import java.util.stream.IntStream;
+
+@Log4j2
+@SpringBootTest
+public class InterestRepositoryTests {
+
+    @Autowired
+    private InterestRepository interestRepository;
+
+    @Test
+    public void testInsertUser(){
+        IntStream.rangeClosed(1,10).forEach(i->{
+            Interest interest = Interest.builder()
+                    .type("취미"+i)
+                    .build();
+            interestRepository.save(interest);
+        });
+    }
+}

--- a/src/test/java/org/dallili/secretfriends/repository/MatchingHistoryRepositoryTests.java
+++ b/src/test/java/org/dallili/secretfriends/repository/MatchingHistoryRepositoryTests.java
@@ -1,0 +1,34 @@
+package org.dallili.secretfriends.repository;
+
+
+import lombok.extern.log4j.Log4j2;
+import org.dallili.secretfriends.domain.MatchingHistory;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+
+import java.util.Random;
+import java.util.stream.IntStream;
+
+@Log4j2
+@SpringBootTest
+public class MatchingHistoryRepositoryTests {
+
+    @Autowired
+    MatchingHistoryRepository matchingHistoryRepository;
+
+    @Test
+    public void testInsertMatchingHistory() {
+
+        Random random = new Random();
+
+        IntStream.rangeClosed(1,30).forEach(i->{
+            MatchingHistory matchingHistory = MatchingHistory.builder()
+                    .userID("user"+random.nextInt(100))
+                    .partnerID("user"+random.nextInt(100))
+                    .build();
+            matchingHistoryRepository.save(matchingHistory);
+        });
+
+    }
+}

--- a/src/test/java/org/dallili/secretfriends/repository/MatchingRepositoryTests.java
+++ b/src/test/java/org/dallili/secretfriends/repository/MatchingRepositoryTests.java
@@ -1,0 +1,5 @@
+package org.dallili.secretfriends.repository;
+// Matching, MatchingHistory, Interest
+
+public class MatchingRepositoryTests {
+}

--- a/src/test/java/org/dallili/secretfriends/repository/MatchingRepositoryTests.java
+++ b/src/test/java/org/dallili/secretfriends/repository/MatchingRepositoryTests.java
@@ -1,5 +1,38 @@
 package org.dallili.secretfriends.repository;
-// Matching, MatchingHistory, Interest
 
+import lombok.extern.log4j.Log4j2;
+import org.dallili.secretfriends.domain.Matching;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+
+import java.time.LocalDateTime;
+import java.util.Random;
+import java.util.stream.IntStream;
+
+@Log4j2
+@SpringBootTest
 public class MatchingRepositoryTests {
+
+    @Autowired
+    MatchingRepository matchingRepository;
+
+    @Test
+    public void testInsertMatching() {
+
+        Random random = new Random();
+
+        IntStream.rangeClosed(1,50).forEach(i-> {
+            Matching matching = Matching.builder()
+                    .userID("user"+i)
+                    .createdAt(LocalDateTime.now())
+                    .firstInterest(Long.valueOf(random.nextInt(10)))
+                    .secondInterest(Long.valueOf(random.nextInt(10)))
+                    .thirdInterest(Long.valueOf(random.nextInt(10)))
+                    .build();
+            matchingRepository.save(matching);
+        });
+
+    }
+
 }

--- a/src/test/java/org/dallili/secretfriends/service/DiaryServiceTests.java
+++ b/src/test/java/org/dallili/secretfriends/service/DiaryServiceTests.java
@@ -29,7 +29,6 @@ public class DiaryServiceTests {
         //Optional<User> partner = userRepository.findById("user10");
 
         DiaryDTO diaryDTO = DiaryDTO.builder()
-                .diaryID("diary107")
                 .color("#123456")
                 .state(true)
                 .userID("user1")

--- a/src/test/java/org/dallili/secretfriends/service/DiaryServiceTests.java
+++ b/src/test/java/org/dallili/secretfriends/service/DiaryServiceTests.java
@@ -31,7 +31,7 @@ public class DiaryServiceTests {
         DiaryDTO diaryDTO = DiaryDTO.builder()
                 .diaryID("diary107")
                 .color("#123456")
-                .isActivated(true)
+                .state(true)
                 .userID("user1")
                 .partnerID("user10")
                 .updatedBy("user10")

--- a/src/test/java/org/dallili/secretfriends/service/MatchingServiceTests.java
+++ b/src/test/java/org/dallili/secretfriends/service/MatchingServiceTests.java
@@ -1,0 +1,21 @@
+package org.dallili.secretfriends.service;
+
+import lombok.extern.log4j.Log4j2;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+
+@SpringBootTest
+@Log4j2
+public class MatchingServiceTests {
+
+    @Autowired
+    MatchingHistoryService matchingHistoryService;
+
+    @Test
+    public void testInsertMatchingHistory() {
+
+        log.info(matchingHistoryService.addHistory("user10", "user20"));
+
+    }
+}


### PR DESCRIPTION
## 작업 내용
- Matching, MatchingHistory, Interest 엔티티 작성
- MatchingRepository, MatchingHistoryRepository, InterestRepository 작성
- Matching, MatchingHistory, Interest 테스트 데이터 생성 코드 작성
- Diary 엔티티 isActivated -> state 변수 이름 변경
- MatchingHistoryDTO 작성
- MatchingHistoryService 등록 메소드 작성
- MatchingController 초대 코드 조회 메소드 작성


## 테스트 내역
![image](https://github.com/Dallili/secretFriends-api/assets/99960721/64752ed8-6250-4a86-980d-ebb26c66d82a)

기본 작업이라고 생각해서 그냥 쭉 작업했는데.. 생각보다 뭐가 많이 늘어났네요.. 
다음부터는 좀 더 짧게 끊어서 풀리퀘 넣겠습니다
