### PR TITLE
[Fix] DiaryServiceTest 실패 해결

### DIFF
--- a/src/main/java/org/dallili/secretfriends/domain/Entry.java
+++ b/src/main/java/org/dallili/secretfriends/domain/Entry.java
@@ -4,6 +4,8 @@ import jakarta.persistence.*;
 import jakarta.validation.constraints.Pattern;
 import lombok.*;
 import org.hibernate.annotations.DynamicInsert;
+import org.hibernate.annotations.OnDelete;
+import org.hibernate.annotations.OnDeleteAction;
 import org.springframework.data.annotation.LastModifiedDate;
 import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 
@@ -29,6 +31,7 @@ public class Entry {
 
     @JoinColumn(name = "diaryID", referencedColumnName = "diaryID", insertable = true, updatable = false)
     @ManyToOne(fetch = FetchType.LAZY) // 여러 개의 페이지가 하나의 다이어리에 속할 수 있음.
+    @OnDelete(action = OnDeleteAction.CASCADE)
     private Diary diary;
 
     @Column(name = "writer")


### PR DESCRIPTION
## 작업 내용
- diary 삭제 시 외래키 제약 조건으로 인해 발생하던 에러 해결

## 구현 방법
- Entry 엔티티 diary 필드에 @OnDelete(action = onDeleteAction.CASCADE) 어노테이션 추가