### PR TITLE
[Feat] 로그인 기능 구현

### DIFF
--- a/src/main/java/org/dallili/secretfriends/config/MySecurityConfig.java
+++ b/src/main/java/org/dallili/secretfriends/config/MySecurityConfig.java
@@ -1,19 +1,42 @@
 package org.dallili.secretfriends.config;
 
 import lombok.RequiredArgsConstructor;
+import org.dallili.secretfriends.jwt.*;
+import org.springframework.boot.autoconfigure.security.servlet.PathRequest;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.security.config.Customizer;
+import org.springframework.security.config.annotation.method.configuration.EnableGlobalMethodSecurity;
+import org.springframework.security.config.annotation.method.configuration.EnableMethodSecurity;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.config.annotation.web.configuration.WebSecurityCustomizer;
+import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
+import org.springframework.security.config.annotation.web.configurers.HeadersConfigurer;
 import org.springframework.security.config.http.SessionCreationPolicy;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
+import org.springframework.security.web.util.matcher.AntPathRequestMatcher;
 
 @RequiredArgsConstructor
 @Configuration
 @EnableWebSecurity
+@EnableMethodSecurity(securedEnabled = true,prePostEnabled = true)
 public class MySecurityConfig{
+
+    private final CustomUserDetailsService customUserDetailsService;
+    private final JwtUtil JwtUtil;
+    private final JwtAuthenticationEntryPoint jwtAuthenticationEntryPoint;
+    private final JwtAccessDeniedHandler jwtAccessDeniedHandler;
+
+    private static final String[] AUTH_WHITELIST = {
+            "/swagger-ui/**", "/swagger-ui.html", "/members", "/members/login",
+            "/v3/api-docs","/api-docs/**","/swagger-resources/**","api-docs/",
+            "/v3/api-docs/**"
+    };
+
     //비밀번호 암호화를 위한 PasswordEncoder 빈 등록
     @Bean
     public PasswordEncoder passwordEncoder(){
@@ -21,12 +44,31 @@ public class MySecurityConfig{
     }
 
     @Bean
-    public SecurityFilterChain filterChain(HttpSecurity http) throws Exception{
-        //CSRF 토큰 비활성화
-        http.csrf(csrf->csrf.disable());
+    public WebSecurityCustomizer webSecurityCustomizer(){
+        return (web)-> web.ignoring().requestMatchers(PathRequest.toStaticResources().atCommonLocations());
+    }  //정적 자원들을 스프링 시큐리티 적용에서 제외
 
-        //세션을 사용하지 않음을 지정
-        http.sessionManagement(config -> config.sessionCreationPolicy(SessionCreationPolicy.STATELESS));
+    @Bean
+    public SecurityFilterChain filterChain(HttpSecurity http) throws Exception{
+
+        http
+                .httpBasic(AbstractHttpConfigurer::disable)
+                //.formLogin(form->form.disable())
+                .csrf(csrf-> csrf.disable())
+                .cors(Customizer.withDefaults())
+                //JwtFilter를 UsernamePasswordAuthenticationFilter 앞에 추가
+                .addFilterBefore(new JwtFilter(customUserDetailsService,JwtUtil), UsernamePasswordAuthenticationFilter.class)
+                //exception handling 할 때 만들었던 클래스를 추가
+                .exceptionHandling(authenticationManager->authenticationManager
+                        .authenticationEntryPoint(jwtAuthenticationEntryPoint)
+                        .accessDeniedHandler(jwtAccessDeniedHandler))
+                .sessionManagement(config -> config.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
+                .headers(header -> header
+                        .frameOptions(HeadersConfigurer.FrameOptionsConfig::sameOrigin))
+                .authorizeHttpRequests(auth->auth
+                        .requestMatchers(AUTH_WHITELIST).permitAll()
+                        .anyRequest().authenticated());
+
 
 
         return http.build();

--- a/src/main/java/org/dallili/secretfriends/config/SwaggerConfig.java
+++ b/src/main/java/org/dallili/secretfriends/config/SwaggerConfig.java
@@ -2,16 +2,43 @@ package org.dallili.secretfriends.config;
 
 import io.swagger.v3.oas.annotations.OpenAPIDefinition;
 import io.swagger.v3.oas.annotations.info.Info;
+import io.swagger.v3.oas.models.Components;
+import io.swagger.v3.oas.models.OpenAPI;
+import io.swagger.v3.oas.models.security.SecurityRequirement;
+import io.swagger.v3.oas.models.security.SecurityScheme;
 import lombok.RequiredArgsConstructor;
 import org.springdoc.core.models.GroupedOpenApi;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.http.HttpHeaders;
+
+import java.util.Arrays;
 
 @OpenAPIDefinition(
         info = @Info(title = "Secret Friends API",version = "v1"))
 @RequiredArgsConstructor
 @Configuration
 public class SwaggerConfig {
+
+
+    @Bean
+    public OpenAPI openAPI(){
+        //Security 스키마 설정
+        SecurityScheme bearerAuth = new SecurityScheme()
+                .type(SecurityScheme.Type.HTTP)
+                .scheme("bearer")
+                .bearerFormat("JWT")
+                .in(SecurityScheme.In.HEADER)
+                .name(HttpHeaders.AUTHORIZATION);
+
+        SecurityRequirement securityRequirement = new SecurityRequirement().addList("bearerAuth");
+
+        return new OpenAPI()
+                .components(new Components()
+                        .addSecuritySchemes("bearerAuth",bearerAuth))
+                .security(Arrays.asList(securityRequirement));
+    }
+
 
     @Bean
     public GroupedOpenApi chatOpenApi() {

--- a/src/main/java/org/dallili/secretfriends/controller/MemberController.java
+++ b/src/main/java/org/dallili/secretfriends/controller/MemberController.java
@@ -31,4 +31,12 @@ public class MemberController {
         return memberService.findMember(memberID);
     }
 
+    @Operation(summary = "로그인")
+    @ResponseStatus(HttpStatus.OK)
+    @PostMapping("/login")
+    public String login(@Valid @RequestBody MemberDTO.LoginRequest request){
+        String token = memberService.login(request);
+        return token;
+    }
+
 }

--- a/src/main/java/org/dallili/secretfriends/domain/Member.java
+++ b/src/main/java/org/dallili/secretfriends/domain/Member.java
@@ -24,13 +24,13 @@ public class Member {
     @Column(name = "memberID", length = 20)
     private Long memberID;
 
-    @Column(name = "email", length = 255)
+    @Column(name = "email", unique = true, nullable = false,length = 255)
     private String email;
 
-    @Column(name = "password", length = 255)
+    @Column(name = "password",nullable = false, length = 255)
     private String password;
 
-    @Column(name = "nickname", length = 20)
+    @Column(name = "nickname", nullable = false, length = 20)
     private String nickname;
 
     @Column(name = "birthday", columnDefinition = "DATE")

--- a/src/main/java/org/dallili/secretfriends/dto/MemberDTO.java
+++ b/src/main/java/org/dallili/secretfriends/dto/MemberDTO.java
@@ -8,6 +8,7 @@ import jakarta.validation.constraints.Size;
 import lombok.Builder;
 import lombok.Data;
 import lombok.NonNull;
+import org.dallili.secretfriends.domain.MemberRole;
 import org.hibernate.validator.constraints.Range;
 
 import java.time.LocalDate;
@@ -47,5 +48,24 @@ public class MemberDTO {
         private LocalDate birthday;
         //@Range(min = 0, max = 3)
         //private int diaryNum;
+    }
+
+    @Data
+    @Builder
+    public static class LoginRequest{
+        @Email
+        @NotBlank(message = "이메일을 입력해주세요.")
+        private String email;
+        @NotBlank(message = "비밀번호를 입력해주세요.")
+        private String password;
+    }
+
+    @Data
+    public static class CustomUserInfo{
+        private Long memberID;
+        private String nickname;
+        private String email;
+        private String password;
+        private MemberRole role;
     }
 }

--- a/src/main/java/org/dallili/secretfriends/jwt/CustomUserDetails.java
+++ b/src/main/java/org/dallili/secretfriends/jwt/CustomUserDetails.java
@@ -1,0 +1,61 @@
+package org.dallili.secretfriends.jwt;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.dallili.secretfriends.dto.MemberDTO;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.core.userdetails.UserDetails;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Getter
+@RequiredArgsConstructor
+public class CustomUserDetails implements UserDetails {
+
+    private final MemberDTO.CustomUserInfo member;
+
+    @Override
+    public Collection<? extends GrantedAuthority> getAuthorities() {
+
+        List<String> roles = new ArrayList<>();
+        roles.add("ROLE_"+member.getRole().toString());
+
+        return roles.stream()
+                .map(SimpleGrantedAuthority::new)
+                .collect(Collectors.toList());
+    }
+
+    @Override
+    public String getPassword() {
+        return member.getPassword();
+    }
+
+    @Override
+    public String getUsername() {
+        return member.getMemberID().toString();
+    }
+
+    @Override
+    public boolean isAccountNonExpired() {
+        return true;
+    }
+
+    @Override
+    public boolean isAccountNonLocked() {
+        return true;
+    }
+
+    @Override
+    public boolean isCredentialsNonExpired() {
+        return true;
+    }
+
+    @Override
+    public boolean isEnabled() {
+        return true;
+    }
+}

--- a/src/main/java/org/dallili/secretfriends/jwt/CustomUserDetailsService.java
+++ b/src/main/java/org/dallili/secretfriends/jwt/CustomUserDetailsService.java
@@ -1,0 +1,30 @@
+package org.dallili.secretfriends.jwt;
+
+import lombok.RequiredArgsConstructor;
+import org.dallili.secretfriends.domain.Member;
+import org.dallili.secretfriends.dto.MemberDTO;
+import org.dallili.secretfriends.repository.MemberRepository;
+import org.modelmapper.ModelMapper;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.core.userdetails.UserDetailsService;
+import org.springframework.security.core.userdetails.UsernameNotFoundException;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@Transactional(readOnly = true)
+@RequiredArgsConstructor
+public class CustomUserDetailsService implements UserDetailsService {
+    private final MemberRepository memberRepository;
+    private final ModelMapper modelMapper;
+
+    @Override
+    public UserDetails loadUserByUsername(String username) throws UsernameNotFoundException {
+        Member member = memberRepository.findById(Long.parseLong(username))
+                .orElseThrow(()-> new UsernameNotFoundException("해당하는 회원이 없습니다."));
+
+        MemberDTO.CustomUserInfo dto = modelMapper.map(member, MemberDTO.CustomUserInfo.class);
+
+        return new CustomUserDetails(dto);
+    }
+}

--- a/src/main/java/org/dallili/secretfriends/jwt/JwtAccessDeniedHandler.java
+++ b/src/main/java/org/dallili/secretfriends/jwt/JwtAccessDeniedHandler.java
@@ -1,0 +1,20 @@
+package org.dallili.secretfriends.jwt;
+
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import org.springframework.security.access.AccessDeniedException;
+import org.springframework.security.web.access.AccessDeniedHandler;
+import org.springframework.stereotype.Component;
+
+import java.io.IOException;
+
+@Component
+public class JwtAccessDeniedHandler implements AccessDeniedHandler {
+
+    @Override
+    public void handle(HttpServletRequest request, HttpServletResponse response, AccessDeniedException accessDeniedException) throws IOException, ServletException {
+        //필요한 권한이 없이 접근하려 할 때 403 error 응답 보냄
+        response.sendError(HttpServletResponse.SC_FORBIDDEN);
+    }
+}

--- a/src/main/java/org/dallili/secretfriends/jwt/JwtAuthenticationEntryPoint.java
+++ b/src/main/java/org/dallili/secretfriends/jwt/JwtAuthenticationEntryPoint.java
@@ -1,0 +1,20 @@
+package org.dallili.secretfriends.jwt;
+
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import org.springframework.security.core.AuthenticationException;
+import org.springframework.security.web.AuthenticationEntryPoint;
+import org.springframework.stereotype.Component;
+
+import java.io.IOException;
+
+@Component
+public class JwtAuthenticationEntryPoint implements AuthenticationEntryPoint {
+
+    @Override
+    public void commence(HttpServletRequest request, HttpServletResponse response, AuthenticationException authException) throws IOException, ServletException {
+        //유효한 자격증명을 제공하지 않고 접근하려 할 때 401 error 응답 보냄
+        response.sendError(HttpServletResponse.SC_UNAUTHORIZED);
+    }
+}

--- a/src/main/java/org/dallili/secretfriends/jwt/JwtFilter.java
+++ b/src/main/java/org/dallili/secretfriends/jwt/JwtFilter.java
@@ -1,0 +1,49 @@
+package org.dallili.secretfriends.jwt;
+
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.util.StringUtils;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+import java.io.IOException;
+
+@RequiredArgsConstructor
+public class JwtFilter extends OncePerRequestFilter { //요청 받을 때 단 한번만 실행
+
+    private final CustomUserDetailsService customUserDetailsService;
+    private final JwtUtil jwtUtil;
+
+    //jwt 토큰 검증 필터 수행
+    @Override
+    protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain) throws ServletException, IOException {
+
+        String authorizationHeader = request.getHeader("Authorization");
+
+        if(authorizationHeader != null && authorizationHeader.startsWith("Bearer")){
+           String token = authorizationHeader.substring(7);
+
+           if(jwtUtil.validateToken(token)){
+               Long userid = jwtUtil.getUserId(token);
+
+               UserDetails userDetails = customUserDetailsService.loadUserByUsername(userid.toString());
+
+               if(userDetails!=null){
+                   UsernamePasswordAuthenticationToken usernamePasswordAuthenticationToken =
+                           new UsernamePasswordAuthenticationToken(userDetails,null,userDetails.getAuthorities());
+
+                   SecurityContextHolder.getContext().setAuthentication(usernamePasswordAuthenticationToken);
+               }
+           }
+        }
+
+        //다음 필터로 넘기기
+        filterChain.doFilter(request,response);
+    }
+}

--- a/src/main/java/org/dallili/secretfriends/jwt/JwtUtil.java
+++ b/src/main/java/org/dallili/secretfriends/jwt/JwtUtil.java
@@ -1,0 +1,111 @@
+package org.dallili.secretfriends.jwt;
+
+import io.jsonwebtoken.*;
+import io.jsonwebtoken.io.Decoders;
+import io.jsonwebtoken.security.Keys;
+import lombok.extern.log4j.Log4j2;
+import org.dallili.secretfriends.dto.JwtTokenDTO;
+import org.dallili.secretfriends.dto.MemberDTO;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.core.userdetails.User;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.stereotype.Component;
+import java.security.Key;
+import java.time.ZonedDateTime;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Date;
+import java.util.stream.Collectors;
+
+
+@Component
+@Log4j2
+public class JwtUtil {
+
+    private static final String AUTHORITIES_KEY = "auth";
+    private static final String BEARER_TYPE = "Bearer";
+    private static final long ACCESS_TOKEN_EXPIRE_TIME = 1000 * 60 * 30; //30분
+    private static final long REFRESH_TOKEN_EXPIRE_TIME = 1000 * 60 * 60 * 24 * 7; //7일
+
+    private final Key key;
+
+    //암호화 키값 생성
+    public JwtUtil(@Value("${jwt.secret}") String key){
+        byte[] keyBytes = Decoders.BASE64.decode(key);
+        this.key = Keys.hmacShaKeyFor(keyBytes);
+    }
+
+    public String generateToken(MemberDTO.CustomUserInfo member){
+
+        Claims claims = Jwts.claims();
+        claims.put("memberID",member.getMemberID());
+        claims.put("email",member.getEmail());
+        claims.put("role",member.getRole());
+
+        ZonedDateTime now = ZonedDateTime.now();
+
+        //Access Token 생성
+        String accessToken = Jwts.builder()
+                .setClaims(claims)
+                .setIssuedAt(Date.from(now.toInstant()))
+                .setExpiration(Date.from(now.plusMinutes(ACCESS_TOKEN_EXPIRE_TIME).toInstant()))
+                .signWith(key, SignatureAlgorithm.HS256)
+                .compact();
+
+        return accessToken;
+    }
+
+    public Authentication getAuthentication(String accessToken){
+        Claims claims = parseClaim(accessToken);
+
+        if(claims.get(AUTHORITIES_KEY) == null){
+            throw new RuntimeException("권한 정보가 없는 토큰입니다.");
+        }
+
+        Collection<? extends GrantedAuthority> authorities =
+                Arrays.stream(claims.get(AUTHORITIES_KEY).toString().split(","))
+                        .map(SimpleGrantedAuthority::new)
+                        .collect(Collectors.toList());
+
+        UserDetails principal = new User(claims.getSubject(),"",authorities);
+
+        return new UsernamePasswordAuthenticationToken(principal,"",authorities);
+    }
+
+    public boolean validateToken(String token){
+        try{
+            Jwts.parserBuilder().setSigningKey(key).build().parseClaimsJws(token);
+            return true;
+        }
+        catch (io.jsonwebtoken.security.SecurityException| MalformedJwtException e){
+            log.info("잘못된 JWT 서명입니다.");
+        } catch (ExpiredJwtException e){
+            log.info("만료된 JWT 토큰입니다.");
+        } catch (UnsupportedJwtException e){
+            log.info("지원되지 않는 JWT 토큰입니다.");
+        } catch (IllegalArgumentException e){
+            log.info("JWT 토큰이 잘못되었습니다.");
+        }
+
+        return false;
+    }
+
+    private Claims parseClaim(String accessToken){
+        try{
+            return Jwts.parserBuilder().setSigningKey(key).build().parseClaimsJws(accessToken).getBody();
+        }catch (ExpiredJwtException e){
+            return e.getClaims();
+        }
+    }
+
+    public Long getUserId(String token){
+        return parseClaim(token).get("memberID",Long.class);
+    }
+
+
+
+}

--- a/src/main/java/org/dallili/secretfriends/jwt/JwtUtil.java
+++ b/src/main/java/org/dallili/secretfriends/jwt/JwtUtil.java
@@ -4,7 +4,6 @@ import io.jsonwebtoken.*;
 import io.jsonwebtoken.io.Decoders;
 import io.jsonwebtoken.security.Keys;
 import lombok.extern.log4j.Log4j2;
-import org.dallili.secretfriends.dto.JwtTokenDTO;
 import org.dallili.secretfriends.dto.MemberDTO;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;

--- a/src/main/java/org/dallili/secretfriends/service/MemberService.java
+++ b/src/main/java/org/dallili/secretfriends/service/MemberService.java
@@ -6,4 +6,5 @@ public interface MemberService{
 
     public void singUp(MemberDTO.SignUpRequest requestDTO);
     public MemberDTO.DetailsResponse findMember(Long memberID);
+    public String login(MemberDTO.LoginRequest requestDTO);
 }

--- a/src/main/java/org/dallili/secretfriends/service/MemberServiceImpl.java
+++ b/src/main/java/org/dallili/secretfriends/service/MemberServiceImpl.java
@@ -4,8 +4,11 @@ import lombok.RequiredArgsConstructor;
 import org.dallili.secretfriends.domain.Member;
 import org.dallili.secretfriends.domain.MemberRole;
 import org.dallili.secretfriends.dto.MemberDTO;
+import org.dallili.secretfriends.jwt.JwtUtil;
 import org.dallili.secretfriends.repository.MemberRepository;
 import org.modelmapper.ModelMapper;
+import org.springframework.security.authentication.BadCredentialsException;
+import org.springframework.security.core.userdetails.UsernameNotFoundException;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 
@@ -16,6 +19,7 @@ public class MemberServiceImpl implements MemberService{
     private final MemberRepository memberRepository;
     private final PasswordEncoder passwordEncoder;
     private final ModelMapper modelMapper;
+    private final JwtUtil jwtUtil;
 
     @Override
     public void singUp(MemberDTO.SignUpRequest requestDTO){
@@ -41,5 +45,22 @@ public class MemberServiceImpl implements MemberService{
         MemberDTO.DetailsResponse response = modelMapper.map(member,MemberDTO.DetailsResponse.class);
 
         return response;
+    }
+
+    @Override
+    public String login(MemberDTO.LoginRequest requestDTO){
+        String email = requestDTO.getEmail();
+        String pwd = requestDTO.getPassword();
+        Member member = memberRepository.findByEmail(email).orElseThrow(()->{
+            throw new UsernameNotFoundException(email + ": 존재하지 않는 회원입니다.");
+        });
+        if(!passwordEncoder.matches(pwd,member.getPassword())){
+            throw new BadCredentialsException("비밀번호가 일치하지 않습니다.");
+        }
+
+        MemberDTO.CustomUserInfo info = modelMapper.map(member, MemberDTO.CustomUserInfo.class);
+
+        String accessToken = jwtUtil.generateToken(info);
+        return accessToken;
     }
 }


### PR DESCRIPTION
## 작업 내용
- 로그인 기능 구현
- jwt 인증 방식 구현
- swagger-ui 에 jwt 기능 설정

## 테스트 여부
- 정상 응답
  ![image](https://github.com/Dallili/secretFriends-api/assets/87927105/924dca8c-952f-43d4-90b9-d5960ca7003b)

## 기타
중간 발표가 얼마 안 남은 시점이라 일단 구현에 초점을 맞추고 작업했다..........
조금 여유로워지면 로그인 로직 변경이라든가 refreshToken 구현 등이 추가될 가능성 有有有有有
[reference](https://sjh9708.tistory.com/170)