### PR TITLE
[feat] 지인 매칭 기능 작성 완료

### DIFF
--- a/src/main/java/org/dallili/secretfriends/controller/MatchingController.java
+++ b/src/main/java/org/dallili/secretfriends/controller/MatchingController.java
@@ -7,9 +7,15 @@ import org.dallili.secretfriends.dto.DiaryDTO;
 import org.dallili.secretfriends.repository.DiaryRepository;
 import org.dallili.secretfriends.service.DiaryService;
 import org.dallili.secretfriends.service.MatchingHistoryService;
+import org.springframework.http.MediaType;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.UUID;
 
 @RestController
 @Log4j2
@@ -20,6 +26,23 @@ public class MatchingController {
     final MatchingHistoryService matchingHistoryService;
 
     final DiaryService diaryService;
+
+    @Operation(summary = "Create Known-Matching Diary POST", description = "지인 매칭을 위한 일기장 생성")
+    @PostMapping(value = "/", consumes = MediaType.APPLICATION_JSON_VALUE)
+    public Map<String, String> knownMatchingDiaryAdd(DiaryDTO.knownMatchingDiary diaryDTO){
+
+        Long diaryID = diaryService.addKnownMatchingDiary(diaryDTO);
+
+        UUID code = diaryService.findCode(diaryID);
+
+        Map<String, String> result = new HashMap<>();
+
+        result.put("diaryID", diaryID.toString());
+        result.put("code", code.toString());
+
+        return result;
+
+    }
 
 /*
     @Operation(summary = "Get Code GET", description = "초대 코드 리턴")

--- a/src/main/java/org/dallili/secretfriends/controller/MatchingController.java
+++ b/src/main/java/org/dallili/secretfriends/controller/MatchingController.java
@@ -8,10 +8,7 @@ import org.dallili.secretfriends.repository.DiaryRepository;
 import org.dallili.secretfriends.service.DiaryService;
 import org.dallili.secretfriends.service.MatchingHistoryService;
 import org.springframework.http.MediaType;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 import java.util.HashMap;
 import java.util.Map;
@@ -44,14 +41,25 @@ public class MatchingController {
 
     }
 
-/*
-    @Operation(summary = "Get Code GET", description = "초대 코드 리턴")
+    @Operation(summary = "Get Code GET", description = "초대 코드 조회")
     @GetMapping(value = "/{diaryID}")
-    public String codeDetails(Long diaryID){
+    public UUID codeDetails(Long diaryID){
 
-        String code = diaryService.findOne(diaryID).getCode();
+        UUID code = diaryService.findCode(diaryID);
 
         return code;
     }
-    */
+
+    @Operation(summary = "Match Knowns PATCH", description = "코드 입력을 통한 다이어리 partner 확정(=지인 매칭 완료)")
+    @PatchMapping(value = "/")
+    public Long partnerModify(String code, Long userID){
+
+        DiaryDTO diaryDTO = diaryService.findDiaryByCode(code);
+        diaryService.modifyUpdate(diaryDTO);
+        diaryService.modifyPartner(diaryDTO.getDiaryID(), userID);
+
+        return diaryDTO.getDiaryID();
+
+    }
+
 }

--- a/src/main/java/org/dallili/secretfriends/controller/MatchingController.java
+++ b/src/main/java/org/dallili/secretfriends/controller/MatchingController.java
@@ -1,6 +1,7 @@
 package org.dallili.secretfriends.controller;
 
 import io.swagger.v3.oas.annotations.Operation;
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.log4j.Log4j2;
 import org.dallili.secretfriends.dto.DiaryDTO;
@@ -26,7 +27,7 @@ public class MatchingController {
 
     @Operation(summary = "Create Known-Matching Diary POST", description = "지인 매칭을 위한 일기장 생성")
     @PostMapping(value = "/", consumes = MediaType.APPLICATION_JSON_VALUE)
-    public Map<String, String> knownMatchingDiaryAdd(DiaryDTO.knownMatchingDiary diaryDTO){
+    public Map<String, String> knownMatchingDiaryAdd(@Valid @RequestBody DiaryDTO diaryDTO){
 
         Long diaryID = diaryService.addKnownMatchingDiary(diaryDTO);
 
@@ -46,7 +47,6 @@ public class MatchingController {
     public UUID codeDetails(Long diaryID){
 
         UUID code = diaryService.findCode(diaryID);
-
         return code;
     }
 

--- a/src/main/java/org/dallili/secretfriends/controller/MatchingController.java
+++ b/src/main/java/org/dallili/secretfriends/controller/MatchingController.java
@@ -27,9 +27,9 @@ public class MatchingController {
 
     @Operation(summary = "Create Known-Matching Diary POST", description = "지인 매칭을 위한 일기장 생성")
     @PostMapping(value = "/", consumes = MediaType.APPLICATION_JSON_VALUE)
-    public Map<String, String> knownMatchingDiaryAdd(@Valid @RequestBody DiaryDTO diaryDTO){
+    public Map<String, String> knownMatchingDiaryAdd(@Valid @RequestBody DiaryDTO.knownMatchingDiary diaryDTO){
 
-        Long diaryID = diaryService.addKnownMatchingDiary(diaryDTO);
+        Long diaryID = diaryService.addKnownsDiary(diaryDTO.getMemberID(), diaryDTO.getColor());
 
         UUID code = diaryService.findCode(diaryID);
 
@@ -50,15 +50,17 @@ public class MatchingController {
         return code;
     }
 
-    @Operation(summary = "Match Knowns PATCH", description = "코드 입력을 통한 다이어리 partner 확정(=지인 매칭 완료)")
+    @Operation(summary = "Match Knowns PATCH", description = "코드 입력을 통한 다이어리 partner 확정 (=지인 매칭 완료)")
     @PatchMapping(value = "/")
     public Long partnerModify(String code, Long userID){
 
         DiaryDTO diaryDTO = diaryService.findDiaryByCode(code);
-        diaryService.modifyUpdate(diaryDTO);
-        diaryService.modifyPartner(diaryDTO.getDiaryID(), userID);
+        Long diaryID = diaryDTO.getDiaryID();
+        diaryService.modifyUpdate(diaryID, userID);
+        diaryService.modifyPartner(diaryID, userID);
+        matchingHistoryService.addHistory(diaryDTO.getMemberID(), userID);
 
-        return diaryDTO.getDiaryID();
+        return diaryID;
 
     }
 

--- a/src/main/java/org/dallili/secretfriends/controller/MatchingController.java
+++ b/src/main/java/org/dallili/secretfriends/controller/MatchingController.java
@@ -52,15 +52,27 @@ public class MatchingController {
 
     @Operation(summary = "Match Knowns PATCH", description = "코드 입력을 통한 다이어리 partner 확정 (=지인 매칭 완료)")
     @PatchMapping(value = "/")
-    public Long partnerModify(String code, Long userID){
+    public Map<String, String> partnerModify(String code, Long userID){
 
         DiaryDTO diaryDTO = diaryService.findDiaryByCode(code);
         Long diaryID = diaryDTO.getDiaryID();
-        diaryService.modifyUpdate(diaryID, userID);
-        diaryService.modifyPartner(diaryID, userID);
-        matchingHistoryService.addHistory(diaryDTO.getMemberID(), userID);
+        Map<String, String> result = new HashMap<>();
 
-        return diaryID;
+        if(diaryDTO.getPartnerID() == null){
+
+            diaryService.modifyUpdate(diaryID, userID);
+            diaryService.modifyPartner(diaryID, userID);
+            matchingHistoryService.addHistory(diaryDTO.getMemberID(), userID);
+
+            result.put("diaryID", diaryID.toString());
+            result.put("state", "매칭 성공");
+            return result;
+        }
+        else {
+            result.put("state", "이미 매칭이 완료된 일기장입니다");
+            return result;
+        }
+
 
     }
 

--- a/src/main/java/org/dallili/secretfriends/dto/DiaryDTO.java
+++ b/src/main/java/org/dallili/secretfriends/dto/DiaryDTO.java
@@ -1,14 +1,17 @@
 package org.dallili.secretfriends.dto;
 
 import com.fasterxml.jackson.annotation.JsonFormat;
+import jakarta.persistence.GeneratedValue;
 import jakarta.validation.constraints.NotEmpty;
 import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
 import lombok.NoArgsConstructor;
 
 import java.time.LocalDateTime;
+import java.util.UUID;
 
 @Data
 @Builder
@@ -33,6 +36,14 @@ public class DiaryDTO {
     private LocalDateTime updatedAt; // get, set
 
     private String color; //get
+
+    private UUID code;
+
+    @Data
+    public static class knownMatchingDiary{
+        private Long memberID;
+        private String color;
+    }
 
 
 }

--- a/src/main/java/org/dallili/secretfriends/dto/DiaryDTO.java
+++ b/src/main/java/org/dallili/secretfriends/dto/DiaryDTO.java
@@ -23,7 +23,7 @@ public class DiaryDTO {
     @NotNull
     private Long diaryID; //get
 
-    @NotEmpty
+    @NotNull
     private Long memberID; //get, set
 
     private Long partnerID; //get, set
@@ -40,6 +40,7 @@ public class DiaryDTO {
     private UUID code;
 
     @Data
+    @Builder
     public static class knownMatchingDiary{
         private Long memberID;
         private String color;

--- a/src/main/java/org/dallili/secretfriends/repository/DiaryRepository.java
+++ b/src/main/java/org/dallili/secretfriends/repository/DiaryRepository.java
@@ -1,7 +1,17 @@
 package org.dallili.secretfriends.repository;
 
 import org.dallili.secretfriends.domain.Diary;
+import org.dallili.secretfriends.domain.Entry;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
 
 public interface DiaryRepository extends JpaRepository<Diary, Long> {
+
+    @Query("SELECT d FROM Diary d WHERE d.code = :code")
+    Optional<Diary> selectDiary(@Param("code") UUID code);
 }

--- a/src/main/java/org/dallili/secretfriends/service/DiaryService.java
+++ b/src/main/java/org/dallili/secretfriends/service/DiaryService.java
@@ -10,6 +10,8 @@ public interface DiaryService {
 
     Long addDiary(DiaryDTO diaryDTO); // 일기장 등록
 
+    Long addKnownMatchingDiary(DiaryDTO.knownMatchingDiary diaryDTO)
+
     DiaryDTO findOne(Long diaryID); // 일기장 조회
 
     void modifyUpdate(DiaryDTO diaryDTO); // 일기장 업데이트 (새로운 답장)

--- a/src/main/java/org/dallili/secretfriends/service/DiaryService.java
+++ b/src/main/java/org/dallili/secretfriends/service/DiaryService.java
@@ -10,7 +10,7 @@ public interface DiaryService {
 
     Long addDiary(DiaryDTO diaryDTO); // 일기장 등록
 
-    Long addKnownMatchingDiary(DiaryDTO.knownMatchingDiary diaryDTO);
+    Long addKnownMatchingDiary(DiaryDTO diaryDTO);
 
     DiaryDTO findOne(Long diaryID); // 일기장 조회
 

--- a/src/main/java/org/dallili/secretfriends/service/DiaryService.java
+++ b/src/main/java/org/dallili/secretfriends/service/DiaryService.java
@@ -12,9 +12,11 @@ public interface DiaryService {
 
     Long addKnownMatchingDiary(DiaryDTO diaryDTO);
 
+    Long addKnownsDiary(Long userID, String color);
+
     DiaryDTO findOne(Long diaryID); // 일기장 조회
 
-    void modifyUpdate(DiaryDTO diaryDTO); // 일기장 업데이트 (새로운 답장)
+    void modifyUpdate(Long diaryID, Long memberID); // 일기장 업데이트 (새로운 답장)
 
     void removeDiary(Long diaryID); // 일기장 삭제
 

--- a/src/main/java/org/dallili/secretfriends/service/DiaryService.java
+++ b/src/main/java/org/dallili/secretfriends/service/DiaryService.java
@@ -4,6 +4,8 @@ import org.dallili.secretfriends.domain.Diary;
 import org.dallili.secretfriends.dto.DiaryDTO;
 
 import java.util.List;
+import java.util.UUID;
+
 public interface DiaryService {
 
     Long addDiary(DiaryDTO diaryDTO); // 일기장 등록
@@ -23,4 +25,8 @@ public interface DiaryService {
     void modifyPartner(Long diaryID, Long partnerID); // 일기장 파트너 결정
 
     void modifyState(Long diaryID); // 일기장 비활성화
+
+    UUID findCode(Long diaryID); //일기장 초대코드 조회
+
+    DiaryDTO findDiaryByCode(String code); // 초대코드로 일기장 조회
 }

--- a/src/main/java/org/dallili/secretfriends/service/DiaryService.java
+++ b/src/main/java/org/dallili/secretfriends/service/DiaryService.java
@@ -10,7 +10,7 @@ public interface DiaryService {
 
     Long addDiary(DiaryDTO diaryDTO); // 일기장 등록
 
-    Long addKnownMatchingDiary(DiaryDTO.knownMatchingDiary diaryDTO)
+    Long addKnownMatchingDiary(DiaryDTO.knownMatchingDiary diaryDTO);
 
     DiaryDTO findOne(Long diaryID); // 일기장 조회
 

--- a/src/main/java/org/dallili/secretfriends/service/DiaryServiceImpl.java
+++ b/src/main/java/org/dallili/secretfriends/service/DiaryServiceImpl.java
@@ -38,7 +38,7 @@ public class DiaryServiceImpl implements DiaryService {
     }
 
     @Override
-    public Long addKnownMatchingDiary(DiaryDTO.knownMatchingDiary diaryDTO){
+    public Long addKnownMatchingDiary(DiaryDTO diaryDTO){
 
         Diary diary = modelMapper.map(diaryDTO, Diary.class);
 
@@ -47,6 +47,8 @@ public class DiaryServiceImpl implements DiaryService {
         diary.makeCode(code);
 
         Long diaryID = diaryRepository.save(diary).getDiaryID();
+
+        diaryRepository.flush();
 
         return diaryID;
 

--- a/src/main/java/org/dallili/secretfriends/service/DiaryServiceImpl.java
+++ b/src/main/java/org/dallili/secretfriends/service/DiaryServiceImpl.java
@@ -13,6 +13,7 @@ import org.springframework.stereotype.Service;
 import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Optional;
+import java.util.UUID;
 import java.util.stream.Collectors;
 
 @Service
@@ -148,6 +149,32 @@ public class DiaryServiceImpl implements DiaryService {
 
 
 
+
+    }
+
+    @Override
+    public UUID findCode(Long diaryID) {
+
+        Optional<Diary> result = diaryRepository.findById(diaryID);
+
+        Diary diary = result.orElseThrow();
+
+        return diary.getCode();
+
+    }
+
+    @Override
+    public DiaryDTO findDiaryByCode(String code){
+
+        UUID uuidCode = UUID.fromString(code);
+
+        Optional<Diary> result = diaryRepository.selectDiary(uuidCode);
+
+        Diary diary = result.orElseThrow();
+
+        DiaryDTO diaryDTO = modelMapper.map(diary, DiaryDTO.class);
+
+        return diaryDTO;
 
     }
 

--- a/src/main/java/org/dallili/secretfriends/service/DiaryServiceImpl.java
+++ b/src/main/java/org/dallili/secretfriends/service/DiaryServiceImpl.java
@@ -54,6 +54,25 @@ public class DiaryServiceImpl implements DiaryService {
 
     }
 
+    @Override
+    public Long addKnownsDiary(Long memberID, String color){
+
+        UUID code = UUID.randomUUID();
+
+        DiaryDTO diaryDTO = DiaryDTO.builder()
+                .memberID(memberID)
+                .color(color)
+                .code(code)
+                .build();
+
+        Diary diary = modelMapper.map(diaryDTO, Diary.class);
+
+        Long diaryID = diaryRepository.save(diary).getDiaryID();
+
+        return diaryID;
+
+    }
+
 
     @Override
     public DiaryDTO findOne(Long diaryID){
@@ -69,16 +88,16 @@ public class DiaryServiceImpl implements DiaryService {
     }
 
     @Override
-    public void modifyUpdate(DiaryDTO diaryDTO) { //일기 전송 후 작동해야하는 메소드.
+    public void modifyUpdate(Long diaryID, Long memberID) { //일기 전송 후 작동해야하는 메소드.
         // 마지막 작성자와 마지막 작성일을 수정한다.
 
-        Optional<Diary> result = diaryRepository.findById(diaryDTO.getDiaryID());
+        Optional<Diary> result = diaryRepository.findById(diaryID);
 
         Diary diary = result.orElseThrow();
 
         //log.info("업데이트 전: " + diary);
 
-        diary.updateDiary(diaryDTO.getUpdatedBy(), LocalDateTime.now());
+        diary.updateDiary(memberID, LocalDateTime.now());
 
         diaryRepository.save(diary);
 

--- a/src/main/java/org/dallili/secretfriends/service/DiaryServiceImpl.java
+++ b/src/main/java/org/dallili/secretfriends/service/DiaryServiceImpl.java
@@ -37,6 +37,21 @@ public class DiaryServiceImpl implements DiaryService {
         return diaryID;
     }
 
+    @Override
+    public Long addKnownMatchingDiary(DiaryDTO.knownMatchingDiary diaryDTO){
+
+        Diary diary = modelMapper.map(diaryDTO, Diary.class);
+
+        UUID code = UUID.randomUUID();
+
+        diary.makeCode(code);
+
+        Long diaryID = diaryRepository.save(diary).getDiaryID();
+
+        return diaryID;
+
+    }
+
 
     @Override
     public DiaryDTO findOne(Long diaryID){

--- a/src/test/java/org/dallili/secretfriends/repository/DiaryRepositoryTests.java
+++ b/src/test/java/org/dallili/secretfriends/repository/DiaryRepositoryTests.java
@@ -9,6 +9,7 @@ import org.springframework.boot.test.context.SpringBootTest;
 
 import java.time.LocalDateTime;
 import java.util.Optional;
+import java.util.UUID;
 import java.util.stream.IntStream;
 
 @SpringBootTest
@@ -42,16 +43,16 @@ public class DiaryRepositoryTests {
     }
 
     @Test
-    public void testInsertBlankDiary(){
-        IntStream.rangeClosed(100,110).forEach(i->{
+    public void testInsertKnownMatchingDiary(){
+        IntStream.rangeClosed(100,150).forEach(i->{
 
-            Optional<Member> member = memberRepository.findById(1L);
-            Optional<Member> partner = memberRepository.findById(2L);
+            Optional<Member> member = memberRepository.findById(i-50L);
+
+            UUID code = UUID.randomUUID();
 
             Diary diary = Diary.builder()
                     .member(member.orElseThrow())
-                    .partner(partner.orElseThrow())
-                    .state(i%2==0?true:false)
+                    .code(code)
                     .color("#000000")
                     .build();
 

--- a/src/test/java/org/dallili/secretfriends/service/DiaryServiceTests.java
+++ b/src/test/java/org/dallili/secretfriends/service/DiaryServiceTests.java
@@ -118,9 +118,11 @@ public class DiaryServiceTests {
     public void testAddKnownMatchingDiary() {
 
         DiaryDTO diaryDTO = DiaryDTO.builder()
-                .memberID(10L)
+                .memberID(12L)
                 .color("123123")
                 .build();
+
+        log.info(diaryDTO);
 
         log.info(diaryService.addKnownMatchingDiary(diaryDTO));
     }

--- a/src/test/java/org/dallili/secretfriends/service/DiaryServiceTests.java
+++ b/src/test/java/org/dallili/secretfriends/service/DiaryServiceTests.java
@@ -1,6 +1,7 @@
 package org.dallili.secretfriends.service;
 
 import lombok.extern.log4j.Log4j2;
+import org.dallili.secretfriends.domain.Diary;
 import org.dallili.secretfriends.dto.DiaryDTO;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -8,6 +9,7 @@ import org.springframework.boot.test.context.SpringBootTest;
 
 import java.time.LocalDateTime;
 import java.util.List;
+import java.util.UUID;
 
 @SpringBootTest
 @Log4j2
@@ -96,6 +98,20 @@ public class DiaryServiceTests {
         List<DiaryDTO> diaries = diaryService.findRepliedDiaries(1L);
 
         log.info(diaries);
+    }
+
+    @Test
+    public void testFindCode() {
+
+        log.info(diaryService.findCode(112L));
+
+    }
+
+    @Test
+    public void testFindByCode() {
+
+
+        log.info(diaryService.findDiaryByCode("cf4dacee-3ffc-40aa-946a-972a98506b38").getDiaryID());
     }
 
 }

--- a/src/test/java/org/dallili/secretfriends/service/DiaryServiceTests.java
+++ b/src/test/java/org/dallili/secretfriends/service/DiaryServiceTests.java
@@ -114,4 +114,15 @@ public class DiaryServiceTests {
         log.info(diaryService.findDiaryByCode("cf4dacee-3ffc-40aa-946a-972a98506b38").getDiaryID());
     }
 
+    @Test
+    public void testAddKnownMatchingDiary() {
+
+        DiaryDTO diaryDTO = DiaryDTO.builder()
+                .memberID(10L)
+                .color("123123")
+                .build();
+
+        log.info(diaryService.addKnownMatchingDiary(diaryDTO));
+    }
+
 }


### PR DESCRIPTION
## 작업 내용 
- 지인 매칭 기능 작성
1. 지인 매칭을 위한 일기장 생성
2. diaryID를 통한 초대 코드 조회
3. 코드 입력을 통한 지인 매칭 확정

## 구현 방법 
3. 코드 입력을 통한 지인 매칭 확정
->diary 테이블에서 partnerID 채우고
-> updated 상황 업데이트(At, By)
-> matchingHistory 기록 추가

##  테스트 내역

1. 지인 매칭을 위한 일기장 생성
![image](https://github.com/Dallili/secretFriends-api/assets/99960721/badf8e41-0f35-4763-9643-36aa87761aac)
![image](https://github.com/Dallili/secretFriends-api/assets/99960721/ee14887a-d68c-4842-b7cf-c91e95be0695)

2. diaryID를 통한 초대 코드 조회
![image](https://github.com/Dallili/secretFriends-api/assets/99960721/c2f17b0a-59a6-465d-9057-b7a2ce0ef57b)

3. 코드 입력을 통한 지인 매칭 확정
![image](https://github.com/Dallili/secretFriends-api/assets/99960721/c3952963-e384-4f1f-9df2-e68208ce6c95)
- 정상 동작
![image](https://github.com/Dallili/secretFriends-api/assets/99960721/528ae716-c6fa-480a-b0de-147d37c54bac)

- 이미 매칭된 일기장인 경우
![image](https://github.com/Dallili/secretFriends-api/assets/99960721/902820e3-56bf-49d2-bffa-623ff345e733)



