### PR TITLE
[Feat] 일기 생성 기능 수정

### DIFF
--- a/src/main/java/org/dallili/secretfriends/controller/EntryController.java
+++ b/src/main/java/org/dallili/secretfriends/controller/EntryController.java
@@ -7,6 +7,7 @@ import lombok.extern.log4j.Log4j2;
 import org.dallili.secretfriends.dto.EntryDTO;
 import org.dallili.secretfriends.service.EntryService;
 import org.springframework.http.MediaType;
+import org.springframework.security.core.Authentication;
 import org.springframework.validation.BindException;
 import org.springframework.validation.BindingResult;
 import org.springframework.web.bind.annotation.*;
@@ -23,16 +24,16 @@ public class EntryController {
 
     private final EntryService entryService;
 
-    @Operation(summary = "Entries POST", description = "일기 생성")
+    @Operation(summary = "일기 생성", description = "일기 생성 후 임시 저장")
     @PostMapping(value = "/", consumes = MediaType.APPLICATION_JSON_VALUE)
-    public Map<String,Long> EntryAdd(@Valid @RequestBody EntryDTO entryDTO, BindingResult bindingResult) throws BindException{
+    public Map<String,Long> EntryAdd(@Valid @RequestBody EntryDTO.CreateRequest entryDTO, Authentication authentication, BindingResult bindingResult) throws BindException{
 
-        log.info(entryDTO);
         if(bindingResult.hasErrors()){
             throw new BindException(bindingResult);
         }
 
         Map<String,Long> result = new HashMap<>();
+        entryDTO.setWriterID(Long.parseLong(authentication.getName()));
 
         Long entryID = entryService.addEntry(entryDTO);
         result.put("entryID",entryID);

--- a/src/main/java/org/dallili/secretfriends/domain/Entry.java
+++ b/src/main/java/org/dallili/secretfriends/domain/Entry.java
@@ -25,21 +25,21 @@ import java.time.LocalDateTime;
 public class Entry {
 
     @Id
-    @Column(name = "entryID")
+    @Column(name = "entry_id")
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long entryID;
 
-    @JoinColumn(name = "diaryID", referencedColumnName = "diaryID", insertable = true, updatable = false)
+    @JoinColumn(name = "diary_id", referencedColumnName = "diaryID", insertable = true, updatable = false)
     @ManyToOne(fetch = FetchType.LAZY) // 여러 개의 페이지가 하나의 다이어리에 속할 수 있음.
     @OnDelete(action = OnDeleteAction.CASCADE)
     private Diary diary;
 
-    @Column(name = "writer")
-    private Long writer;
+    @Column(name = "writer_id")
+    private Long writerID;
 
-    @Column(name = "date", columnDefinition = "TIMESTAMP")
+    @Column(name = "updatedAt", columnDefinition = "TIMESTAMP")
     @LastModifiedDate
-    private LocalDateTime date;
+    private LocalDateTime updatedAt;
 
     @Column(name = "content", columnDefinition = "TEXT")
     private String content;

--- a/src/main/java/org/dallili/secretfriends/dto/EntryDTO.java
+++ b/src/main/java/org/dallili/secretfriends/dto/EntryDTO.java
@@ -1,35 +1,37 @@
 package org.dallili.secretfriends.dto;
 
 import com.fasterxml.jackson.annotation.JsonFormat;
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import jakarta.validation.constraints.NotBlank;
-import jakarta.validation.constraints.Pattern;
+import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Size;
-import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
-import lombok.NoArgsConstructor;
+import org.dallili.secretfriends.domain.Diary;
+import org.dallili.secretfriends.domain.Entry;
 
 import java.time.LocalDateTime;
 
-@Data
-@Builder
-@AllArgsConstructor
-@NoArgsConstructor
 public class EntryDTO {
 
-    private Long entryID;
-    @NotBlank
-    private Long diaryID;
-    @NotBlank
-    private Long writer;
-    @JsonFormat(pattern = "yyyy-MM-dd HH:mm:ss")
-    private LocalDateTime date;
-    @Size(min = 1, message = "일기 내용은 1자 이상 작성해야 한다.")
-    private String content;
-    @JsonFormat(pattern = "yyyy-MM-dd HH:mm:ss")
-    private LocalDateTime sendAt;
-    @Pattern(regexp = "[YN]", message = "state는 Y 혹은 N 값 중 하나여야 한다.")
-    private String state;
+    @Data
+    @Builder
+    public static class CreateRequest{
+        @NotNull
+        private Long diaryID;
+        @Size(min = 1, message = "일기 내용은 1자 이상 작성해야 한다.")
+        private String content;
+        @JsonIgnore
+        private Long writerID;
+
+        public Entry toEntity(Diary diary){
+            return Entry.builder()
+                    .diary(diary)
+                    .writerID(this.writerID)
+                    .content(this.content)
+                    .build();
+        }
+    }
 
     @Data
     @Builder

--- a/src/main/java/org/dallili/secretfriends/service/DiaryService.java
+++ b/src/main/java/org/dallili/secretfriends/service/DiaryService.java
@@ -34,4 +34,5 @@ public interface DiaryService {
 
     DiaryDTO findDiaryByCode(String code); // 초대코드로 일기장 조회
 
+    Diary findDiaryById(Long id);
 }

--- a/src/main/java/org/dallili/secretfriends/service/DiaryServiceImpl.java
+++ b/src/main/java/org/dallili/secretfriends/service/DiaryServiceImpl.java
@@ -1,5 +1,6 @@
 package org.dallili.secretfriends.service;
 
+import jakarta.persistence.EntityNotFoundException;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.log4j.Log4j2;
 import org.dallili.secretfriends.domain.Diary;
@@ -213,5 +214,11 @@ public class DiaryServiceImpl implements DiaryService {
 
     }
 
-
+    @Override
+    public Diary findDiaryById(Long id) {
+        Diary diary = diaryRepository.findById(id).orElseThrow(()->{
+            return new EntityNotFoundException(id + ": 존재하지 않는 일기장입니다.");
+        });
+        return diary;
+    }
 }

--- a/src/main/java/org/dallili/secretfriends/service/EntryService.java
+++ b/src/main/java/org/dallili/secretfriends/service/EntryService.java
@@ -7,7 +7,7 @@ import java.util.List;
 
 @Transactional
 public interface EntryService {
-    Long addEntry(EntryDTO entryDTO);
+    Long addEntry(EntryDTO.CreateRequest entryDTO);
     Boolean modifyState(Long entryID);
     EntryDTO.UnsentEntryResponse modifyContent(EntryDTO.ModifyRequest entryDTO);
     List<EntryDTO.SentEntryResponse> findSentEntry(Long diaryID);

--- a/src/main/java/org/dallili/secretfriends/service/EntryServiceImpl.java
+++ b/src/main/java/org/dallili/secretfriends/service/EntryServiceImpl.java
@@ -3,6 +3,7 @@ package org.dallili.secretfriends.service;
 import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.log4j.Log4j2;
+import org.dallili.secretfriends.domain.Diary;
 import org.dallili.secretfriends.domain.Entry;
 import org.dallili.secretfriends.dto.EntryDTO;
 import org.dallili.secretfriends.repository.EntryRepository;
@@ -22,10 +23,17 @@ public class EntryServiceImpl implements EntryService {
 
     private final EntryRepository entryRepository;
     private final ModelMapper modelMapper;
+    private final DiaryService diaryService;
 
     @Override
-    public Long addEntry(EntryDTO entryDTO) {
-        Entry entry = modelMapper.map(entryDTO, Entry.class);
+    public Long addEntry(EntryDTO.CreateRequest entryDTO) {
+        Diary diary = diaryService.findDiaryById(entryDTO.getDiaryID());
+
+        if(!(entryDTO.getWriterID()==diary.getMember().getMemberID()||entryDTO.getWriterID()==diary.getPartner().getMemberID())){
+            throw new IllegalArgumentException("작성 권한이 없는 일기장입니다.");
+        }
+
+        Entry entry = entryDTO.toEntity(diary);
         Long eid = entryRepository.save(entry).getEntryID();
         return eid;
     }

--- a/src/test/java/org/dallili/secretfriends/repository/EntryRepositoryTests.java
+++ b/src/test/java/org/dallili/secretfriends/repository/EntryRepositoryTests.java
@@ -25,7 +25,7 @@ public class EntryRepositoryTests {
         IntStream.rangeClosed(1,10).forEach(i->{
             Entry entry = Entry.builder()
                     .diary(diary)
-                    .writer(diary.getMember().getMemberID())
+                    .writerID(diary.getMember().getMemberID())
                     .content("일기 텍스트...")
                     .build();
 

--- a/src/test/java/org/dallili/secretfriends/service/EntryServiceTests.java
+++ b/src/test/java/org/dallili/secretfriends/service/EntryServiceTests.java
@@ -23,21 +23,15 @@ public class EntryServiceTests {
 
     @Test
     public void testAddEntry(){
-        EntryDTO entryDTO = EntryDTO.builder()
-                .diaryID(2L)
-                .writer(1L)
+        EntryDTO.CreateRequest entryDTO = EntryDTO.CreateRequest.builder()
+                .diaryID(1L)
+                .writerID(1L)
                 .content("일기")
                 .build();
 
         Long eid = entryService.addEntry(entryDTO);
 
-        Entry entry = entryRepository.findById(eid).get();
         log.info(eid);
-
-        assertThat(entry.getEntryID()).isEqualTo(eid);
-        assertThat(entry.getDiary().getDiaryID()).isEqualTo("diary2");
-        assertThat(entry.getWriter()).isEqualTo("member2");
-        assertThat(entry.getContent()).isEqualTo("일기");
     }
 
     @Test


### PR DESCRIPTION
## 작업 내용
- Entry 엔티티 필드명 변경 
- 일기 생성 요청 포맷 변경
- 일기 생성 시 요청한 회원 id와 다이어리 주인 id 비교/검증하는 로직 추가