### PR TITLE
[Feat] 일기 조회 기능 수정

### DIFF
--- a/src/main/java/org/dallili/secretfriends/domain/Diary.java
+++ b/src/main/java/org/dallili/secretfriends/domain/Diary.java
@@ -19,16 +19,16 @@ import java.util.UUID;
 public class Diary{
 
     @Id
-    @Column(name = "diaryID", length = 20)
+    @Column(name = "diary_id", length = 20)
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long diaryID;
 
     @ManyToOne(fetch = FetchType.LAZY) //여러 개의 diary가 하나의 user에 속할 수 있음
-    @JoinColumn(name = "memberID", referencedColumnName = "memberID", insertable = true, updatable = false)
+    @JoinColumn(name = "member_id", referencedColumnName = "member_id", insertable = true, updatable = false)
     private Member member;
 
     @ManyToOne(fetch = FetchType.LAZY) //여러 개의 diary가 하나의 user에 속할 수 있음
-    @JoinColumn(name = "partnerID", referencedColumnName = "memberID", insertable = true, updatable = true)
+    @JoinColumn(name = "partner_id", referencedColumnName = "member_id", insertable = true, updatable = true)
     private Member partner;
 
     @Column(name = "state",columnDefinition = "TINYINT")

--- a/src/main/java/org/dallili/secretfriends/domain/Entry.java
+++ b/src/main/java/org/dallili/secretfriends/domain/Entry.java
@@ -16,9 +16,9 @@ import java.time.LocalDateTime;
 @Builder
 @AllArgsConstructor
 @NoArgsConstructor
-@ToString(exclude = "diary")
+@ToString(exclude = {"diary","member"})
 @Table(name = "entry", indexes = {
-        @Index(name="idx_entry_diary_diaryID", columnList = "diaryID")
+        @Index(name="idx_entry_diary_diaryID", columnList = "diary_id")
 })
 @EntityListeners(value = {AuditingEntityListener.class})
 @DynamicInsert
@@ -29,13 +29,15 @@ public class Entry {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long entryID;
 
-    @JoinColumn(name = "diary_id", referencedColumnName = "diaryID", insertable = true, updatable = false)
+    @JoinColumn(name = "diary_id", referencedColumnName = "diary_id", insertable = true, updatable = false)
     @ManyToOne(fetch = FetchType.LAZY) // 여러 개의 페이지가 하나의 다이어리에 속할 수 있음.
     @OnDelete(action = OnDeleteAction.CASCADE)
     private Diary diary;
 
-    @Column(name = "writer_id")
-    private Long writerID;
+    @JoinColumn(name = "writer_id", referencedColumnName = "member_id", insertable = true, updatable = false)
+    @ManyToOne(fetch = FetchType.LAZY)
+    @OnDelete(action = OnDeleteAction.CASCADE)
+    private Member member;
 
     @Column(name = "updatedAt", columnDefinition = "TIMESTAMP")
     @LastModifiedDate

--- a/src/main/java/org/dallili/secretfriends/domain/Entry.java
+++ b/src/main/java/org/dallili/secretfriends/domain/Entry.java
@@ -3,6 +3,7 @@ package org.dallili.secretfriends.domain;
 import jakarta.persistence.*;
 import jakarta.validation.constraints.Pattern;
 import lombok.*;
+import org.dallili.secretfriends.dto.EntryDTO;
 import org.hibernate.annotations.DynamicInsert;
 import org.hibernate.annotations.OnDelete;
 import org.hibernate.annotations.OnDeleteAction;
@@ -70,6 +71,23 @@ public class Entry {
         if(this.state.equals("Y")){
             throw new IllegalStateException("전달된 일기는 내용 수정 불가");
         }
+    }
+
+    public EntryDTO.UnsentEntryResponse toUnsentDto(){
+        return EntryDTO.UnsentEntryResponse.builder()
+                .entryID(this.getEntryID())
+                .writerName(this.getMember().getNickname())
+                .updatedAt(this.getUpdatedAt())
+                .content(this.getContent())
+                .build();
+    }
+    public EntryDTO.SentEntryResponse toSentDto(){
+        return EntryDTO.SentEntryResponse.builder()
+                .entryID(this.getEntryID())
+                .writerName(this.getMember().getNickname())
+                .sendAt(this.getSendAt())
+                .content(this.getContent())
+                .build();
     }
 
 }

--- a/src/main/java/org/dallili/secretfriends/domain/Interest.java
+++ b/src/main/java/org/dallili/secretfriends/domain/Interest.java
@@ -13,7 +13,7 @@ import lombok.*;
 public class Interest {
 
     @Id
-    @Column(name = "interestID")
+    @Column(name = "interest_id")
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long interestID;
 

--- a/src/main/java/org/dallili/secretfriends/domain/Matching.java
+++ b/src/main/java/org/dallili/secretfriends/domain/Matching.java
@@ -15,23 +15,23 @@ import java.time.LocalDateTime;
 public class Matching {
 
     @Id
-    @Column(name = "matchingID")
+    @Column(name = "matching_id")
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long matchingID;
 
-    @JoinColumn(name = "memberID", referencedColumnName = "memberID", insertable = true, updatable = true)
+    @JoinColumn(name = "member_id", referencedColumnName = "member_id", insertable = true, updatable = true)
     private Long memberID;
 
     @Column(name = "createdAt", columnDefinition = "TIMESTAMP")
     private LocalDateTime createdAt;
 
-    @JoinColumn(name = "firstInterest", referencedColumnName = "interestID", insertable = true, updatable = true)
+    @JoinColumn(name = "firstInterest", referencedColumnName = "interest_id", insertable = true, updatable = true)
     private Long firstInterest;
 
-    @JoinColumn(name = "secondInterest", referencedColumnName = "interestID", insertable = true, updatable = true)
+    @JoinColumn(name = "secondInterest", referencedColumnName = "interest_id", insertable = true, updatable = true)
     private Long secondInterest;
 
-    @JoinColumn(name = "thirdInterest", referencedColumnName = "interestID", insertable = true, updatable = true)
+    @JoinColumn(name = "thirdInterest", referencedColumnName = "interest_id", insertable = true, updatable = true)
     private Long thirdInterest;
 
 

--- a/src/main/java/org/dallili/secretfriends/domain/MatchingHistory.java
+++ b/src/main/java/org/dallili/secretfriends/domain/MatchingHistory.java
@@ -15,14 +15,14 @@ import java.time.LocalDateTime;
 public class MatchingHistory {
 
     @Id
-    @Column(name = "historyID")
+    @Column(name = "history_id")
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long historyID;
 
-    @JoinColumn(name = "memberID", referencedColumnName = "memberID", insertable = true, updatable = true)
+    @JoinColumn(name = "member_id", referencedColumnName = "member_id", insertable = true, updatable = true)
     private String memberID;
 
-    @JoinColumn(name = "partnerID", referencedColumnName = "memberID", insertable = true, updatable = true)
+    @JoinColumn(name = "partner_id", referencedColumnName = "member_id", insertable = true, updatable = true)
     private String partnerID;
 
 }

--- a/src/main/java/org/dallili/secretfriends/domain/Member.java
+++ b/src/main/java/org/dallili/secretfriends/domain/Member.java
@@ -21,7 +21,7 @@ public class Member {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
-    @Column(name = "memberID", length = 20)
+    @Column(name = "member_id", length = 20)
     private Long memberID;
 
     @Column(name = "email", unique = true, nullable = false,length = 255)

--- a/src/main/java/org/dallili/secretfriends/dto/EntryDTO.java
+++ b/src/main/java/org/dallili/secretfriends/dto/EntryDTO.java
@@ -9,6 +9,7 @@ import lombok.Builder;
 import lombok.Data;
 import org.dallili.secretfriends.domain.Diary;
 import org.dallili.secretfriends.domain.Entry;
+import org.dallili.secretfriends.domain.Member;
 
 import java.time.LocalDateTime;
 
@@ -24,10 +25,10 @@ public class EntryDTO {
         @JsonIgnore
         private Long writerID;
 
-        public Entry toEntity(Diary diary){
+        public Entry toEntity(Diary diary, Member member){
             return Entry.builder()
                     .diary(diary)
-                    .writerID(this.writerID)
+                    .member(member)
                     .content(this.content)
                     .build();
         }
@@ -44,22 +45,22 @@ public class EntryDTO {
     @Data
     public static class UnsentEntryResponse{
         private Long entryID;
-        @NotBlank
-        private Long writer;
+        private String writerName;
         @JsonFormat(pattern = "yyyy-MM-dd HH:mm:ss")
         private LocalDateTime date;
-        @Size(min = 1, message = "일기 내용은 1자 이상 작성해야 한다.")
         private String content;
+
+//        public UnsentEntryResponse toDto(Entry entry){
+//
+//        }
     }
 
     @Data
     public static class SentEntryResponse{
         private Long entryID;
-        @NotBlank
-        private Long writer;
+        private String writerName;
         @JsonFormat(pattern = "yyyy-MM-dd HH:mm:ss")
         private LocalDateTime sendAt;
-        @Size(min = 1, message = "일기 내용은 1자 이상 작성해야 한다.")
         private String content;
     }
 

--- a/src/main/java/org/dallili/secretfriends/dto/EntryDTO.java
+++ b/src/main/java/org/dallili/secretfriends/dto/EntryDTO.java
@@ -43,19 +43,17 @@ public class EntryDTO {
     }
 
     @Data
+    @Builder
     public static class UnsentEntryResponse{
         private Long entryID;
         private String writerName;
         @JsonFormat(pattern = "yyyy-MM-dd HH:mm:ss")
-        private LocalDateTime date;
+        private LocalDateTime updatedAt;
         private String content;
-
-//        public UnsentEntryResponse toDto(Entry entry){
-//
-//        }
     }
 
     @Data
+    @Builder
     public static class SentEntryResponse{
         private Long entryID;
         private String writerName;

--- a/src/main/java/org/dallili/secretfriends/service/EntryServiceImpl.java
+++ b/src/main/java/org/dallili/secretfriends/service/EntryServiceImpl.java
@@ -71,7 +71,7 @@ public class EntryServiceImpl implements EntryService {
     public List<EntryDTO.SentEntryResponse> findSentEntry(Long diaryID) {
         List<Entry> entries = entryRepository.selectEntry(diaryID,"Y");
 
-        List<EntryDTO.SentEntryResponse> dto = entries.stream().map(entry -> modelMapper.map(entry,EntryDTO.SentEntryResponse.class)).collect(Collectors.toList());
+        List<EntryDTO.SentEntryResponse> dto = entries.stream().map(entry -> entry.toSentDto() ).collect(Collectors.toList());
 
         return dto;
     }
@@ -80,7 +80,7 @@ public class EntryServiceImpl implements EntryService {
     public List<EntryDTO.UnsentEntryResponse> findUnsentEntry(Long diaryID) {
         List<Entry> entries = entryRepository.selectEntry(diaryID,"N");
 
-        List<EntryDTO.UnsentEntryResponse> dto = entries.stream().map(entry -> modelMapper.map(entry,EntryDTO.UnsentEntryResponse.class)).collect(Collectors.toList());
+        List<EntryDTO.UnsentEntryResponse> dto = entries.stream().map(entry -> entry.toUnsentDto()).collect(Collectors.toList());
 
         return dto;
     }

--- a/src/main/java/org/dallili/secretfriends/service/EntryServiceImpl.java
+++ b/src/main/java/org/dallili/secretfriends/service/EntryServiceImpl.java
@@ -5,6 +5,7 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.log4j.Log4j2;
 import org.dallili.secretfriends.domain.Diary;
 import org.dallili.secretfriends.domain.Entry;
+import org.dallili.secretfriends.domain.Member;
 import org.dallili.secretfriends.dto.EntryDTO;
 import org.dallili.secretfriends.repository.EntryRepository;
 import org.modelmapper.ModelMapper;
@@ -24,6 +25,7 @@ public class EntryServiceImpl implements EntryService {
     private final EntryRepository entryRepository;
     private final ModelMapper modelMapper;
     private final DiaryService diaryService;
+    private final MemberService memberService;
 
     @Override
     public Long addEntry(EntryDTO.CreateRequest entryDTO) {
@@ -33,7 +35,9 @@ public class EntryServiceImpl implements EntryService {
             throw new IllegalArgumentException("작성 권한이 없는 일기장입니다.");
         }
 
-        Entry entry = entryDTO.toEntity(diary);
+        Member member = memberService.findMemberById(entryDTO.getWriterID());
+
+        Entry entry = entryDTO.toEntity(diary,member);
         Long eid = entryRepository.save(entry).getEntryID();
         return eid;
     }

--- a/src/main/java/org/dallili/secretfriends/service/MemberService.java
+++ b/src/main/java/org/dallili/secretfriends/service/MemberService.java
@@ -1,5 +1,6 @@
 package org.dallili.secretfriends.service;
 
+import org.dallili.secretfriends.domain.Member;
 import org.dallili.secretfriends.dto.MemberDTO;
 
 public interface MemberService{
@@ -7,4 +8,6 @@ public interface MemberService{
     public void singUp(MemberDTO.SignUpRequest requestDTO);
     public MemberDTO.DetailsResponse findMember(Long memberID);
     public String login(MemberDTO.LoginRequest requestDTO);
+
+    public Member findMemberById(Long memberID);
 }

--- a/src/main/java/org/dallili/secretfriends/service/MemberServiceImpl.java
+++ b/src/main/java/org/dallili/secretfriends/service/MemberServiceImpl.java
@@ -1,5 +1,6 @@
 package org.dallili.secretfriends.service;
 
+import jakarta.persistence.EntityNotFoundException;
 import lombok.RequiredArgsConstructor;
 import org.dallili.secretfriends.domain.Member;
 import org.dallili.secretfriends.domain.MemberRole;
@@ -38,9 +39,7 @@ public class MemberServiceImpl implements MemberService{
     @Override
     public MemberDTO.DetailsResponse findMember(Long memberID) {
 
-        Member member = memberRepository.findById(memberID).orElseThrow(()->{
-            throw new IllegalStateException(memberID + ": 존재하지 않는 회원입니다.");
-        });
+        Member member = findMemberById(memberID);
 
         MemberDTO.DetailsResponse response = modelMapper.map(member,MemberDTO.DetailsResponse.class);
 
@@ -62,5 +61,13 @@ public class MemberServiceImpl implements MemberService{
 
         String accessToken = jwtUtil.generateToken(info);
         return accessToken;
+    }
+
+    @Override
+    public Member findMemberById(Long memberID) {
+        Member member = memberRepository.findById(memberID).orElseThrow(()->{
+            throw new EntityNotFoundException(memberID + ": 존재하지 않는 회원입니다.");
+        });
+        return member;
     }
 }

--- a/src/test/java/org/dallili/secretfriends/repository/EntryRepositoryTests.java
+++ b/src/test/java/org/dallili/secretfriends/repository/EntryRepositoryTests.java
@@ -3,6 +3,7 @@ package org.dallili.secretfriends.repository;
 import lombok.extern.log4j.Log4j2;
 import org.dallili.secretfriends.domain.Diary;
 import org.dallili.secretfriends.domain.Entry;
+import org.dallili.secretfriends.domain.Member;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
@@ -17,15 +18,17 @@ public class EntryRepositoryTests {
     private EntryRepository entryRepository;
     @Autowired
     private DiaryRepository diaryRepository;
+    @Autowired MemberRepository memberRepository;
 
     @Test
     public void testInsertEntry(){
-        Diary diary = diaryRepository.findById(2L).orElseThrow();
+        Diary diary = diaryRepository.findById(1L).orElseThrow();
+        Member member = memberRepository.findById(diary.getMember().getMemberID()).orElseThrow();
 
         IntStream.rangeClosed(1,10).forEach(i->{
             Entry entry = Entry.builder()
                     .diary(diary)
-                    .writerID(diary.getMember().getMemberID())
+                    .member(member)
                     .content("일기 텍스트...")
                     .build();
 


### PR DESCRIPTION
## 작업 내용
- 일기 조회 기능 응답 포맷 변경
    - 기존 응답 → 작성자의 memberId 반환
    ```
    {
      "total": 2,
      "unsent": [
        {
          "entryID": 13,
          "writer": "user1",
          "date": "2024-03-27 16:08:34",
          "content": "일기 텍스트..."
        }
      ],
      "sent": [
        {
          "entryID": 11,
          "writer": "user1",
          "sendAt": "2024-03-31 00:26:58",
          "content": "수정된 일기"
        },
        {
          "entryID": 12,
          "writer": "user1",
          "sendAt": "2024-03-31 00:27:22",
          "content": "일기 텍스트..."
        }
      ]
    }
  ```
    - 변경 후 응답 → 작성자의 nickname 반환
    ```
    {
      "total": 1,
      "unsent": [
        {
          "entryID": 2,
          "writerName": "반짝이는 마녀",
          "updatedAt": "2024-04-14 14:28:29",
          "content": "답장 보내여"
        }
      ],
      "sent": [
        {
          "entryID": 1,
          "writerName": "반짝이는 마녀",
          "sendAt": "2024-04-14 14:28:36",
          "content": "string"
        }
      ]
    }
  ```
- 데이터베이스 칼럼명 변경 ex. memberid → member_id

## 기타
데이터베이스 스키마가 변경돼서 한번 데이터베이스 드롭했다가 실행하는 게 좋을 것 같아유