### PR TITLE
[feat] findRepliedDiaries(),  findStateDiaries() 기능 수정

### DIFF
--- a/src/main/java/org/dallili/secretfriends/domain/Diary.java
+++ b/src/main/java/org/dallili/secretfriends/domain/Diary.java
@@ -40,7 +40,7 @@ public class Diary{
     @Column(name = "updatedAt",columnDefinition = "TIMESTAMP")
     private LocalDateTime updatedAt;
 
-    @Column(name = "color", length = 7)
+    @Column(name = "color", length = 20)
     private String color;
 
     @Column(name="code", columnDefinition = "VARBINARY(36)")

--- a/src/main/java/org/dallili/secretfriends/service/DiaryServiceImpl.java
+++ b/src/main/java/org/dallili/secretfriends/service/DiaryServiceImpl.java
@@ -161,16 +161,22 @@ public class DiaryServiceImpl implements DiaryService {
 
     @Override
     public List<DiaryDTO> findStateDiaries(Long memberID, Boolean state) {
-
         List<Diary> diaries = diaryRepository.findAll();
 
         return diaries.stream()
                 .filter(diary -> diary.isState() == state)
-                .filter(diary -> memberID.equals(diary.getMember().getMemberID()) || memberID.equals(diary.getPartner().getMemberID()))
-                .map(diary -> modelMapper.map(diary, DiaryDTO.class) )
+                .filter(diary -> {
+                    if (diary.getPartner() != null) {
+                        return memberID.equals(diary.getMember().getMemberID()) ||
+                                memberID.equals(diary.getPartner().getMemberID());
+                    } else {
+                        return memberID.equals(diary.getMember().getMemberID());
+                    }
+                })
+                .map(diary -> modelMapper.map(diary, DiaryDTO.class))
                 .collect(Collectors.toList());
-
     }
+
   
     @Override
     public List<DiaryDTO> findRepliedDiaries(Long loginMemberID){

--- a/src/main/java/org/dallili/secretfriends/service/DiaryServiceImpl.java
+++ b/src/main/java/org/dallili/secretfriends/service/DiaryServiceImpl.java
@@ -179,6 +179,7 @@ public class DiaryServiceImpl implements DiaryService {
 
         return diaries.stream()
                 .filter(diary -> diary.isState() == true)
+                .filter(diary -> diary.getPartner()!=null)
                 .filter(diary -> loginMemberID.equals(diary.getMember().getMemberID()) || loginMemberID.equals(diary.getPartner().getMemberID()))
                 .filter(diary -> diary.getUpdatedBy()!=null)
                 .filter(diary -> !loginMemberID.equals(diary.getUpdatedBy()))

--- a/src/test/java/org/dallili/secretfriends/service/DiaryServiceTests.java
+++ b/src/test/java/org/dallili/secretfriends/service/DiaryServiceTests.java
@@ -95,7 +95,7 @@ public class DiaryServiceTests {
     @Test
     public void testFindRepliedDiaries() {
 
-        List<DiaryDTO> diaries = diaryService.findRepliedDiaries(1L);
+        List<DiaryDTO> diaries = diaryService.findRepliedDiaries(100L);
 
         log.info(diaries);
     }

--- a/src/test/java/org/dallili/secretfriends/service/DiaryServiceTests.java
+++ b/src/test/java/org/dallili/secretfriends/service/DiaryServiceTests.java
@@ -87,7 +87,7 @@ public class DiaryServiceTests {
     @Test
     public void testFindStateDiaries(){
 
-        List<DiaryDTO> diaries = diaryService.findStateDiaries(1L, true);
+        List<DiaryDTO> diaries = diaryService.findStateDiaries(2L, true);
 
         log.info(diaries);
     }


### PR DESCRIPTION
## 작업 내용
- partnerID null인 일기장까지 조회할 때 NullPointerException 발생
- 에러 발생하지 않도록 findRepliedDiaries(), findStateDiaries() 기능에 조건 추가