### PR TITLE
[Feat] 일기 전달 기능 수정

### DIFF
--- a/src/main/java/org/dallili/secretfriends/controller/EntryController.java
+++ b/src/main/java/org/dallili/secretfriends/controller/EntryController.java
@@ -59,8 +59,9 @@ public class EntryController {
 
     @Operation(summary = "일기 전달", description = "저장된 일기의 state, sendAt 필드 값 업데이트")
     @PatchMapping(value = "/{entryID}")
-    public Map<String,String> stateModify(@PathVariable("entryID") Long entryID){
-        Boolean result = entryService.modifyState(entryID);
+    public Map<String,String> stateModify(@PathVariable("entryID") Long entryID, Authentication authentication){
+        Long memberID = Long.parseLong(authentication.getName());
+        Boolean result = entryService.modifyState(entryID,memberID);
         if(result){
             return Map.of("entryID",Long.toString(entryID),
                     "result","일기 전달 성공");

--- a/src/main/java/org/dallili/secretfriends/service/EntryService.java
+++ b/src/main/java/org/dallili/secretfriends/service/EntryService.java
@@ -8,7 +8,7 @@ import java.util.List;
 @Transactional
 public interface EntryService {
     Long addEntry(EntryDTO.CreateRequest entryDTO);
-    Boolean modifyState(Long entryID);
+    Boolean modifyState(Long entryID, Long memberID);
     EntryDTO.UnsentEntryResponse modifyContent(EntryDTO.ModifyRequest entryDTO);
     List<EntryDTO.SentEntryResponse> findSentEntry(Long diaryID);
     List<EntryDTO.UnsentEntryResponse> findUnsentEntry(Long diaryID);

--- a/src/main/java/org/dallili/secretfriends/service/EntryServiceImpl.java
+++ b/src/main/java/org/dallili/secretfriends/service/EntryServiceImpl.java
@@ -44,13 +44,20 @@ public class EntryServiceImpl implements EntryService {
     }
 
     @Override
-    public Boolean modifyState(Long entryID) {
+    @Transactional
+    public Boolean modifyState(Long entryID, Long memberID) {
         Entry entry = entryRepository.findById(entryID).orElseThrow(()->{
             throw new EntityNotFoundException("존재하지 않는 일기입니다.");
         });
+
+        if(!(entry.getMember().getMemberID().equals(memberID))){
+            throw new IllegalArgumentException("전달 권한이 없는 일기입니다.");
+        }
+
         if(entry.getState().equals("N")){
             entryRepository.updateState(entryID);
             entryRepository.updateSendAt(entryID, LocalDateTime.now());
+            diaryService.modifyUpdate(entry.getDiary().getDiaryID(),memberID);
             return true;
         } else
             return false;

--- a/src/test/java/org/dallili/secretfriends/service/EntryServiceTests.java
+++ b/src/test/java/org/dallili/secretfriends/service/EntryServiceTests.java
@@ -50,7 +50,8 @@ public class EntryServiceTests {
     @Test
     public void testModifyState(){
         Long eid = 4L;
-        Boolean result = entryService.modifyState(eid);
+        Long senderId = 1L;
+        Boolean result = entryService.modifyState(eid,senderId);
         log.info(result);
     }
 


### PR DESCRIPTION
## 작업 내용
- 일기 전달 api 호출 시 다이어리 필드도 (updatedAt, updatedBy) 수정되도록 구현