### PR TITLE
[feat] 욕설 필터링 기능 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -68,6 +68,9 @@ dependencies {
     runtimeOnly 'io.jsonwebtoken:jjwt-impl:0.11.5',
             'io.jsonwebtoken:jjwt-jackson:0.11.5'
 
+    //욕설 필터링 라이브러리
+    implementation 'io.github.vaneproject:badwordfiltering:1.0.0'
+
 }
 
 tasks.named('test') {

--- a/src/main/java/org/dallili/secretfriends/controller/EntryController.java
+++ b/src/main/java/org/dallili/secretfriends/controller/EntryController.java
@@ -7,6 +7,7 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.log4j.Log4j2;
 import org.dallili.secretfriends.dto.EntryDTO;
 import org.dallili.secretfriends.service.EntryService;
+import org.dallili.secretfriends.service.MemberService;
 import org.springframework.http.MediaType;
 import org.springframework.security.core.Authentication;
 import org.springframework.validation.BindException;
@@ -24,6 +25,8 @@ import java.util.Map;
 public class EntryController {
 
     private final EntryService entryService;
+
+    private final MemberService memberService;
 
     @Operation(summary = "일기 생성", description = "일기 생성 후 임시 저장")
     @PostMapping(value = "/", consumes = MediaType.APPLICATION_JSON_VALUE)
@@ -76,7 +79,7 @@ public class EntryController {
     @GetMapping(value = "/list/{diaryID}")
     public Map<String,Object> entryList(@PathVariable("diaryID") Long diaryID, Authentication authentication){
         Long memberID = Long.parseLong(authentication.getName());
-        Boolean useFiltering = entryService.findMemberUseFiltering(memberID);
+        Boolean useFiltering = memberService.findMemberUseFiltering(memberID);
 
         List<EntryDTO.SentEntryResponse> SentEntry = entryService.findSentEntry(diaryID);
         List<EntryDTO.UnsentEntryResponse> UnsentEntry = entryService.findUnsentEntry(diaryID);

--- a/src/main/java/org/dallili/secretfriends/controller/EntryController.java
+++ b/src/main/java/org/dallili/secretfriends/controller/EntryController.java
@@ -1,5 +1,6 @@
 package org.dallili.secretfriends.controller;
 
+import com.vane.badwordfiltering.BadWordFiltering;
 import io.swagger.v3.oas.annotations.Operation;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
@@ -73,14 +74,23 @@ public class EntryController {
 
     @Operation(summary = "일기 조회", description = "특정 다이어리의 일기 목록 조회")
     @GetMapping(value = "/list/{diaryID}")
-    public Map<String,Object> entryList(@PathVariable("diaryID") Long diaryID){
+    public Map<String,Object> entryList(@PathVariable("diaryID") Long diaryID, Authentication authentication){
+        Long memberID = Long.parseLong(authentication.getName());
+        Boolean useFiltering = entryService.findMemberUseFiltering(memberID);
+
         List<EntryDTO.SentEntryResponse> SentEntry = entryService.findSentEntry(diaryID);
         List<EntryDTO.UnsentEntryResponse> UnsentEntry = entryService.findUnsentEntry(diaryID);
-
         Map<String,Object> result = new HashMap<>();
+
+        if (useFiltering == true){
+            SentEntry = entryService.modifyTextFiltering(SentEntry);
+        }
+
         result.put("total",SentEntry.size());
         result.put("sent",SentEntry);
         result.put("unsent",UnsentEntry);
+
+
 
         return result;
     }

--- a/src/main/java/org/dallili/secretfriends/dto/EntryDTO.java
+++ b/src/main/java/org/dallili/secretfriends/dto/EntryDTO.java
@@ -60,6 +60,8 @@ public class EntryDTO {
         @JsonFormat(pattern = "yyyy-MM-dd HH:mm:ss")
         private LocalDateTime sendAt;
         private String content;
+
+        public void changeContent(String content){ this.content = content; }
     }
 
 }

--- a/src/main/java/org/dallili/secretfriends/service/EntryService.java
+++ b/src/main/java/org/dallili/secretfriends/service/EntryService.java
@@ -4,6 +4,7 @@ import jakarta.transaction.Transactional;
 import org.dallili.secretfriends.dto.EntryDTO;
 
 import java.util.List;
+import java.util.Map;
 
 @Transactional
 public interface EntryService {
@@ -12,4 +13,7 @@ public interface EntryService {
     EntryDTO.UnsentEntryResponse modifyContent(EntryDTO.ModifyRequest entryDTO);
     List<EntryDTO.SentEntryResponse> findSentEntry(Long diaryID);
     List<EntryDTO.UnsentEntryResponse> findUnsentEntry(Long diaryID);
+    Boolean findMemberUseFiltering (Long memberID);
+    List<EntryDTO.SentEntryResponse> modifyTextFiltering(List<EntryDTO.SentEntryResponse> entry);
+
 }

--- a/src/main/java/org/dallili/secretfriends/service/EntryService.java
+++ b/src/main/java/org/dallili/secretfriends/service/EntryService.java
@@ -13,7 +13,6 @@ public interface EntryService {
     EntryDTO.UnsentEntryResponse modifyContent(EntryDTO.ModifyRequest entryDTO);
     List<EntryDTO.SentEntryResponse> findSentEntry(Long diaryID);
     List<EntryDTO.UnsentEntryResponse> findUnsentEntry(Long diaryID);
-    Boolean findMemberUseFiltering (Long memberID);
     List<EntryDTO.SentEntryResponse> modifyTextFiltering(List<EntryDTO.SentEntryResponse> entry);
 
 }

--- a/src/main/java/org/dallili/secretfriends/service/EntryServiceImpl.java
+++ b/src/main/java/org/dallili/secretfriends/service/EntryServiceImpl.java
@@ -1,5 +1,6 @@
 package org.dallili.secretfriends.service;
 
+import com.vane.badwordfiltering.BadWordFiltering;
 import jakarta.persistence.EntityNotFoundException;
 import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
@@ -13,7 +14,9 @@ import org.modelmapper.ModelMapper;
 import org.springframework.stereotype.Service;
 
 import java.time.LocalDateTime;
+import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 import java.util.stream.Collectors;
 
@@ -93,5 +96,19 @@ public class EntryServiceImpl implements EntryService {
         List<EntryDTO.UnsentEntryResponse> dto = entries.stream().map(entry -> entry.toUnsentDto()).collect(Collectors.toList());
 
         return dto;
+    }
+    @Override
+    public Boolean findMemberUseFiltering (Long memberID){
+        Member member = memberService.findMemberById(memberID);
+        return member.isUseFiltering();
+    }
+    public List<EntryDTO.SentEntryResponse> modifyTextFiltering(List<EntryDTO.SentEntryResponse> entry){
+
+        BadWordFiltering badWordFiltering = new BadWordFiltering();
+        for (EntryDTO.SentEntryResponse sentEntry : entry) {
+            String filteredText = badWordFiltering.change(sentEntry.getContent());
+            sentEntry.changeContent(filteredText);
+        }
+        return entry;
     }
 }

--- a/src/main/java/org/dallili/secretfriends/service/EntryServiceImpl.java
+++ b/src/main/java/org/dallili/secretfriends/service/EntryServiceImpl.java
@@ -97,11 +97,6 @@ public class EntryServiceImpl implements EntryService {
 
         return dto;
     }
-    @Override
-    public Boolean findMemberUseFiltering (Long memberID){
-        Member member = memberService.findMemberById(memberID);
-        return member.isUseFiltering();
-    }
     public List<EntryDTO.SentEntryResponse> modifyTextFiltering(List<EntryDTO.SentEntryResponse> entry){
 
         BadWordFiltering badWordFiltering = new BadWordFiltering();

--- a/src/main/java/org/dallili/secretfriends/service/MemberService.java
+++ b/src/main/java/org/dallili/secretfriends/service/MemberService.java
@@ -11,4 +11,5 @@ public interface MemberService{
     public Member findMemberById(Long memberID);
     public void modifyPassword(Long memberID, String password);
     public void modifyMember(Long memberID, MemberDTO.ModifyRequest request);
+    public Boolean findMemberUseFiltering (Long memberID);
 }

--- a/src/main/java/org/dallili/secretfriends/service/MemberServiceImpl.java
+++ b/src/main/java/org/dallili/secretfriends/service/MemberServiceImpl.java
@@ -85,4 +85,10 @@ public class MemberServiceImpl implements MemberService{
         member.modifyProfile(request.getNickname(),request.getBirthday());
         memberRepository.save(member);
     }
+
+    @Override
+    public Boolean findMemberUseFiltering (Long memberID){
+        Member member = findMemberById(memberID);
+        return member.isUseFiltering();
+    }
 }

--- a/src/test/java/org/dallili/secretfriends/service/EntryServiceTests.java
+++ b/src/test/java/org/dallili/secretfriends/service/EntryServiceTests.java
@@ -67,4 +67,18 @@ public class EntryServiceTests {
         List<EntryDTO.UnsentEntryResponse> dto = entryService.findUnsentEntry(diaryID);
         dto.stream().forEach(i -> log.info(i));
     }
+
+    @Test
+    public void testmodifyTextFiltering() {
+
+        List<EntryDTO.SentEntryResponse> entry = entryService.findSentEntry(1L);
+
+        log.info(entryService.modifyTextFiltering(entry));
+    }
+
+    @Test
+    public void testfindMemberUseFiltering() {
+
+        log.info(entryService.findMemberUseFiltering(101L));
+    }
 }


### PR DESCRIPTION
## 작업 내용
- gradle 욕설 필터링 라이브러리 추가
- Entryservice에 
       findMemberUseFiltering (Long memberID), 
       modifyTextFiltering(List<EntryDTO.SentEntryResponse> entry) 함수 작성
- EntryController에서 "일기 조회" 기능 수정.
       사용자가 필터링을 사용하는 경우, 이미 보내진 일기의 content들에 대해 욕설 필터링 되도록 함. (**으로 대체)

## 테스트 내역
![필터](https://github.com/Dallili/secretFriends-api/assets/99960721/f77d2008-128c-452c-afbb-6079898bf2c6)
- useFiltering == 0일 때
- 아직 필터링 되지 않은 모습 확인
![필터 x-2](https://github.com/Dallili/secretFriends-api/assets/99960721/db4001bc-9a64-477c-9d69-20ab62633f33)
- useFiltering == 1일 때
- **으로 필터링 된 모습 확인
![필터 o-2](https://github.com/Dallili/secretFriends-api/assets/99960721/16ae0e8a-3e63-4904-807e-9dbda735ebdd)
