### PR TITLE
[Feat] 비밀번호 변경 기능 수정

### DIFF
--- a/src/main/java/org/dallili/secretfriends/controller/MemberController.java
+++ b/src/main/java/org/dallili/secretfriends/controller/MemberController.java
@@ -47,7 +47,7 @@ public class MemberController {
     @PatchMapping("/pw")
     public void passwordModify(@RequestBody @Valid MemberDTO.PasswordRequest request, Authentication authentication){
         Long memberId = Long.parseLong(authentication.getName());
-        memberService.modifyPassword(memberId, request.getPassword());
+        memberService.modifyPassword(memberId, request);
     }
 
 }

--- a/src/main/java/org/dallili/secretfriends/dto/MemberDTO.java
+++ b/src/main/java/org/dallili/secretfriends/dto/MemberDTO.java
@@ -64,8 +64,12 @@ public class MemberDTO {
 
     @Data
     public static class PasswordRequest{
-        @NotBlank(message = "비밀번호를 입력해주세요.")
+        @NotBlank(message = "'현재 비밀번호' 항목을 입력해주세요.")
+        private String oldPassword;
+        @NotBlank(message = "'새 비밀번호' 항목을 입력해주세요.")
         @Size(min=5, message = "비밀번호가 너무 짧습니다. (최소 5글자)")
-        private String password;
+        private String newPassword;
+        @NotBlank(message = "'새 비밀번호 확인' 항목을 입력해주세요.")
+        private String confirmPassword;
     }
 }

--- a/src/main/java/org/dallili/secretfriends/service/MemberService.java
+++ b/src/main/java/org/dallili/secretfriends/service/MemberService.java
@@ -11,5 +11,5 @@ public interface MemberService{
 
     public Member findMemberById(Long memberID);
 
-    public void modifyPassword(Long memberID, String password);
+    public void modifyPassword(Long memberID, MemberDTO.PasswordRequest requestDTO);
 }

--- a/src/main/java/org/dallili/secretfriends/service/MemberServiceImpl.java
+++ b/src/main/java/org/dallili/secretfriends/service/MemberServiceImpl.java
@@ -73,9 +73,20 @@ public class MemberServiceImpl implements MemberService{
     }
 
     @Override
-    public void modifyPassword(Long memberID, String password) {
+    public void modifyPassword(Long memberID, MemberDTO.PasswordRequest requestDTO) {
         Member member = findMemberById(memberID);
-        member.changePassword(passwordEncoder.encode(password));
+
+        String oldPassword = member.getPassword();
+
+        if(!(passwordEncoder.matches(requestDTO.getOldPassword(),oldPassword))){
+            throw new IllegalArgumentException("현재 비밀번호가 틀립니다.");
+        }
+
+        if(!requestDTO.getNewPassword().equals(requestDTO.getConfirmPassword())){
+            throw new IllegalArgumentException("새로 변경할 비밀번호 입력이 서로 동일하지 않습니다.");
+        }
+
+        member.changePassword(passwordEncoder.encode(requestDTO.getNewPassword()));
         memberRepository.save(member);
     }
 }


### PR DESCRIPTION
## 작업 내용
- PasswordRequestDTO 필드 추가
- MemberService 수정
  - 기존 비밀번호 검증
  - 새로운 비밀번호 입력이 서로 일치하는지 확인

## 테스트 여부
- 기존 비밀번호 입력이 틀렸을 때 응답
  <img width="776" alt="image" src="https://github.com/Dallili/secretFriends-api/assets/87927105/e2aa1dba-2bf1-4fe3-a0f1-d5287b615dd5">

- 새로운 비밀번호 입력이 서로 일치하지 않을 때 응답
  <img width="779" alt="image" src="https://github.com/Dallili/secretFriends-api/assets/87927105/50671f55-d914-49e9-8c42-19eb994c3864">
