### PR TITLE
[Feat] 비속어 필터링 설정 변경 기능 구현

### DIFF
--- a/src/main/java/org/dallili/secretfriends/controller/MemberController.java
+++ b/src/main/java/org/dallili/secretfriends/controller/MemberController.java
@@ -50,4 +50,12 @@ public class MemberController {
         memberService.modifyPassword(memberId, request);
     }
 
+    @Operation(summary = "비속어 필터링 설정 변경")
+    @ResponseStatus(HttpStatus.OK)
+    @PatchMapping("/useFiltering")
+    public void filteringModify(@RequestBody @Valid MemberDTO.FilteringUpdateRequest request, Authentication authentication){
+        Long memberId = Long.parseLong(authentication.getName());
+        memberService.modifyFiltering(memberId, request);
+    }
+
 }

--- a/src/main/java/org/dallili/secretfriends/domain/Member.java
+++ b/src/main/java/org/dallili/secretfriends/domain/Member.java
@@ -59,6 +59,10 @@ public class Member {
         this.password = password;
     }
 
+    public void changeFiltering(boolean useFiltering){
+        this.useFiltering = useFiltering;
+    }
+
     public void addRole(MemberRole memberRole){
         this.role = memberRole;
     }

--- a/src/main/java/org/dallili/secretfriends/dto/MemberDTO.java
+++ b/src/main/java/org/dallili/secretfriends/dto/MemberDTO.java
@@ -73,4 +73,10 @@ public class MemberDTO {
         @NotBlank(message = "'새 비밀번호 확인' 항목을 입력해주세요.")
         private String confirmPassword;
     }
+
+    @Data
+    public static class FilteringUpdateRequest{
+        @NotNull
+        private boolean useFiltering;
+    }
 }

--- a/src/main/java/org/dallili/secretfriends/dto/MemberDTO.java
+++ b/src/main/java/org/dallili/secretfriends/dto/MemberDTO.java
@@ -41,6 +41,7 @@ public class MemberDTO {
         private String gender;
         @JsonFormat(pattern = "yyyy-MM-dd")
         private LocalDate birthday;
+        private boolean useFiltering;
         //@Range(min = 0, max = 3)
         //private int diaryNum;
     }

--- a/src/main/java/org/dallili/secretfriends/service/MemberService.java
+++ b/src/main/java/org/dallili/secretfriends/service/MemberService.java
@@ -12,4 +12,6 @@ public interface MemberService{
     public Member findMemberById(Long memberID);
 
     public void modifyPassword(Long memberID, MemberDTO.PasswordRequest requestDTO);
+
+    public void modifyFiltering(Long memberID, MemberDTO.FilteringUpdateRequest request);
 }

--- a/src/main/java/org/dallili/secretfriends/service/MemberServiceImpl.java
+++ b/src/main/java/org/dallili/secretfriends/service/MemberServiceImpl.java
@@ -89,4 +89,11 @@ public class MemberServiceImpl implements MemberService{
         member.changePassword(passwordEncoder.encode(requestDTO.getNewPassword()));
         memberRepository.save(member);
     }
+
+    @Override
+    public void modifyFiltering(Long memberID, MemberDTO.FilteringUpdateRequest request) {
+        Member member = findMemberById(memberID);
+        member.changeFiltering(request.isUseFiltering());
+        memberRepository.save(member);
+    }
 }


### PR DESCRIPTION
## 작업 내용
- 회원 조회 기능 수정: 회원 정보 조회 시 필터링 여부 데이터도 함께 전달되도록 구현
- 비속어 필터링 설정 변경 기능 구현

## 테스트 여부
- 필터링 설정 변경에 성공했을 경우 응답
  ![image](https://github.com/Dallili/secretFriends-api/assets/87927105/9d385486-7692-4237-9405-f33a20672134)
