### PR TITLE
[feat] NotifyController 알림 목록 조회 기능 구현

### DIFF
--- a/src/main/java/org/dallili/secretfriends/notify/controller/EmitterController.java
+++ b/src/main/java/org/dallili/secretfriends/notify/controller/EmitterController.java
@@ -13,7 +13,7 @@ import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
 @RestController
 @Log4j2
 @RequiredArgsConstructor
-@RequestMapping("/notify")
+@RequestMapping("/emitter")
 public class EmitterController {
 
     private final EmitterService emitterService;

--- a/src/main/java/org/dallili/secretfriends/notify/controller/NotifyController.java
+++ b/src/main/java/org/dallili/secretfriends/notify/controller/NotifyController.java
@@ -15,7 +15,7 @@ import java.util.List;
 @RestController
 @Log4j2
 @RequiredArgsConstructor
-@RequestMapping("/notify2")
+@RequestMapping("/notify")
 public class NotifyController {
 
     private final NotifyService notifyService;

--- a/src/main/java/org/dallili/secretfriends/notify/controller/NotifyController.java
+++ b/src/main/java/org/dallili/secretfriends/notify/controller/NotifyController.java
@@ -1,0 +1,29 @@
+package org.dallili.secretfriends.notify.controller;
+
+import io.swagger.v3.oas.annotations.Operation;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.log4j.Log4j2;
+import org.dallili.secretfriends.notify.dto.NotifyDTO;
+import org.dallili.secretfriends.notify.service.NotifyService;
+import org.springframework.security.core.Authentication;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
+
+@RestController
+@Log4j2
+@RequiredArgsConstructor
+@RequestMapping("/notify2")
+public class NotifyController {
+
+    private final NotifyService notifyService;
+    @Operation(summary = "Notify List GET", description = "알림 목록 조회")
+    @GetMapping(value = "/")
+    public List<NotifyDTO> notifyDTOList (Authentication authentication){
+        return notifyService.findAllNotify(Long.parseLong(authentication.getName()));
+    }
+
+
+}

--- a/src/main/java/org/dallili/secretfriends/notify/dto/NotifyDTO.java
+++ b/src/main/java/org/dallili/secretfriends/notify/dto/NotifyDTO.java
@@ -2,16 +2,14 @@ package org.dallili.secretfriends.notify.dto;
 
 import com.fasterxml.jackson.annotation.JsonFormat;
 import jakarta.validation.constraints.NotNull;
-import lombok.AllArgsConstructor;
-import lombok.Builder;
-import lombok.Data;
-import lombok.NoArgsConstructor;
+import lombok.*;
 import org.dallili.secretfriends.notify.domain.Notify;
 
 import java.time.LocalDateTime;
 
 @Data
 @Builder
+@Getter
 @AllArgsConstructor
 @NoArgsConstructor
 
@@ -32,5 +30,11 @@ public class NotifyDTO {
 
     public enum NotifyType{
         NEWDIARY, REPLY, INACTIVATE
+    }
+
+    //modelmapper 매핑 규칙 정의를 위한 setter
+    //일반 코드 작성 시에는 사용 지양
+    public void setNotifyType(Enum<NotifyType> notifyType) {
+        this.notifyType = notifyType;
     }
 }

--- a/src/main/java/org/dallili/secretfriends/notify/repository/NotifyRepository.java
+++ b/src/main/java/org/dallili/secretfriends/notify/repository/NotifyRepository.java
@@ -1,8 +1,16 @@
 package org.dallili.secretfriends.notify.repository;
 
+import org.dallili.secretfriends.domain.Diary;
+import org.dallili.secretfriends.domain.Member;
 import org.dallili.secretfriends.notify.domain.Notify;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+
 public interface NotifyRepository extends JpaRepository<Notify, Long> {
+
+      List<Notify> findAllByReceiver_MemberID(Long receiverID);
 
 }

--- a/src/main/java/org/dallili/secretfriends/notify/service/NotifyService.java
+++ b/src/main/java/org/dallili/secretfriends/notify/service/NotifyService.java
@@ -2,11 +2,13 @@ package org.dallili.secretfriends.notify.service;
 
 import org.dallili.secretfriends.notify.dto.NotifyDTO;
 
+import java.util.List;
+
 public interface NotifyService {
 
-    // "2. notify 테이블에 알림 데이터 저장" 담당하는 메소드
+    // notify 테이블에 알림 데이터 저장" 담당하는 메소드
     void saveNotifyTable(Long receiverID, Long senderID, NotifyDTO.NotifyType type);
-
     void removeNotify(Long notifyID);
+    List<NotifyDTO> findAllNotify(Long receiverID);
 
 }

--- a/src/main/java/org/dallili/secretfriends/notify/service/NotifyServiceImpl.java
+++ b/src/main/java/org/dallili/secretfriends/notify/service/NotifyServiceImpl.java
@@ -9,6 +9,8 @@ import org.modelmapper.ModelMapper;
 import org.springframework.stereotype.Service;
 
 import java.time.LocalDateTime;
+import java.util.List;
+import java.util.stream.Collectors;
 
 @Service
 @Log4j2
@@ -26,8 +28,9 @@ public class NotifyServiceImpl implements NotifyService{
                 .receiverID(receiverID)
                 .senderID(senderID)
                 .build();
-        //log.info(receiverNotifyDTO);
+        log.info(receiverNotifyDTO);
         Notify receiverNotify = modelMapper.map(receiverNotifyDTO, Notify.class);
+        log.info(receiverNotify);
         notifyRepository.save(receiverNotify);
 
         if(type == NotifyDTO.NotifyType.NEWDIARY || type == NotifyDTO.NotifyType.INACTIVATE){
@@ -44,5 +47,20 @@ public class NotifyServiceImpl implements NotifyService{
 
     public void removeNotify(Long notifyID){
         notifyRepository.deleteById(notifyID);
+    }
+
+    public List<NotifyDTO> findAllNotify(Long receiverID){
+        List<Notify> notifyList = notifyRepository.findAllByReceiver_MemberID(receiverID);
+
+        List<NotifyDTO> notifyDTOList = notifyList.stream()
+                .map(notify -> {
+                    NotifyDTO notifyDTO = modelMapper.map(notify, NotifyDTO.class);
+                    // notificationType 가공하여 NotifyDTO에 추가
+                    notifyDTO.setNotifyType(NotifyDTO.NotifyType.valueOf(notify.getNotifyType()));
+                    return notifyDTO;
+                })
+                .collect(Collectors.toList());
+
+        return notifyDTOList;
     }
 }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -12,7 +12,7 @@ spring:
       show-sql: true
       
   profiles:
-    active: prod
+    active: local
 
 logging:
   level:

--- a/src/test/java/org/dallili/secretfriends/repository/NotifyRepositoryTests.java
+++ b/src/test/java/org/dallili/secretfriends/repository/NotifyRepositoryTests.java
@@ -18,7 +18,7 @@ public class NotifyRepositoryTests {
 
     @Autowired
     private MemberRepository memberRepository;
-
+/*
     @Test
     public void testInsert() {
 
@@ -32,5 +32,5 @@ public class NotifyRepositoryTests {
                 .build();
 
         notifyRepository.save(notify);
-    }
+    }*/
 }

--- a/src/test/java/org/dallili/secretfriends/service/NotifyServiceTests.java
+++ b/src/test/java/org/dallili/secretfriends/service/NotifyServiceTests.java
@@ -18,12 +18,17 @@ public class NotifyServiceTests {
     @Test
     public void testSaveNotify() {
 
-        notifyService.saveNotifyTable(1L, 2L, NotifyDTO.NotifyType.NEWDIARY);
+        notifyService.saveNotifyTable(1L, 2L, NotifyDTO.NotifyType.INACTIVATE);
     }
 
     @Test
     public void testRemoveNotify(){
-        notifyService.removeNotify(1L);
+        notifyService.removeNotify(3L);
 
+    }
+
+    @Test
+    public void testFindAllNotify() {
+        log.info(notifyService.findAllNotify(2L));
     }
 }


### PR DESCRIPTION
## 작업 내용
- NotifyService.findAllNotify() 작성 
   로그인 유저의 알림 목록 조회
- NotifyController 알림 목록 조회 기능 구현
   로그인 후 최초 알림 목록 불러올 때 사용
- EmitterController 매핑 uri "/notify" -> "/emitter" 변경

## 테스트 내역

![image](https://github.com/Dallili/secretFriends-api/assets/99960721/4d2b1d52-9648-438f-bb9d-b5bd2db58e88)
![image](https://github.com/Dallili/secretFriends-api/assets/99960721/0b812efb-0bde-4a6d-ad57-3d7a0e272b86)

