### PR TITLE
[feat] 일기장 회수 기능 구현

### DIFF
--- a/src/main/java/org/dallili/secretfriends/controller/DiaryController.java
+++ b/src/main/java/org/dallili/secretfriends/controller/DiaryController.java
@@ -72,4 +72,12 @@ public class DiaryController {
 
     }
 
+    @Operation(summary = "Diary Take Back PATCH", description = "일기장 회수")
+    @PatchMapping(value = "/{diaryID}/takeBack")
+    public void diaryTakeBackModify (@PathVariable("diaryID") Long diaryID, Authentication authentication){
+
+        diaryService.modifyDiaryTakeBack(diaryID, Long.parseLong(authentication.getName()));
+
+    }
+
 }

--- a/src/main/java/org/dallili/secretfriends/service/DiaryService.java
+++ b/src/main/java/org/dallili/secretfriends/service/DiaryService.java
@@ -35,4 +35,6 @@ public interface DiaryService {
     DiaryDTO findDiaryByCode(String code); // 초대코드로 일기장 조회
 
     Diary findDiaryById(Long id);
+
+    void modifyDiaryTakeBack(Long diaryID, Long memberID);
 }

--- a/src/main/java/org/dallili/secretfriends/service/DiaryServiceImpl.java
+++ b/src/main/java/org/dallili/secretfriends/service/DiaryServiceImpl.java
@@ -12,6 +12,7 @@ import org.modelmapper.ModelMapper;
 import org.springframework.stereotype.Service;
 
 import java.time.LocalDateTime;
+import java.time.temporal.ChronoUnit;
 import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
@@ -228,5 +229,23 @@ public class DiaryServiceImpl implements DiaryService {
             return new EntityNotFoundException(id + ": 존재하지 않는 일기장입니다.");
         });
         return diary;
+    }
+
+    @Override
+    public void modifyDiaryTakeBack(Long diaryID, Long memberID){
+
+        Optional<Diary> result = diaryRepository.findById(diaryID);
+
+        Diary diary = result.orElseThrow();
+
+        LocalDateTime lastUpdated = diary.getUpdatedAt();
+        LocalDateTime now = LocalDateTime.now();
+
+        if (ChronoUnit.DAYS.between(lastUpdated, now) >= 14) {
+            modifyUpdate(diaryID, memberID);
+        } else {
+            throw new IllegalStateException("아직 회수할 수 없습니다.");
+        }
+
     }
 }

--- a/src/test/java/org/dallili/secretfriends/service/DiaryServiceTests.java
+++ b/src/test/java/org/dallili/secretfriends/service/DiaryServiceTests.java
@@ -126,4 +126,10 @@ public class DiaryServiceTests {
         log.info(diaryService.addKnownMatchingDiary(diaryDTO));
     }
 
+    @Test
+    public void testTakeBack(){
+        diaryService.modifyDiaryTakeBack(152L, 101L);
+
+    }
+
 }


### PR DESCRIPTION
### 작업 내용
- 일기장 회수 기능 diaryController.diaryTakeBackModify() 작성
- diaryService.modifyDiaryTakeBack() 작성
- 회수 기준은 "마지막 업데이트로부터 14일이 지났는가"

### 테스트 내역
- 마지막 업데이트로부터 14일이 지난 일기장의 경우
![image](https://github.com/Dallili/secretFriends-api/assets/99960721/4304de29-11c2-49ef-bedf-3e52dee6f478)
- 아직 14일이 지나지 않은 일기장의 경우
![image](https://github.com/Dallili/secretFriends-api/assets/99960721/5b9334aa-3837-4ac0-b271-1bb2b9c8418c)

