### PR TITLE
[feat] DiaryController.diaryDTOList 매칭 안된 일기장에 matchingID 포함하도록 수정

### DIFF
--- a/src/main/java/org/dallili/secretfriends/controller/DiaryController.java
+++ b/src/main/java/org/dallili/secretfriends/controller/DiaryController.java
@@ -39,15 +39,12 @@ public class DiaryController {
         Long memberID = Long.parseLong(authentication.getName());
 
         List<DiaryDTO> diaries = diaryService.findStateDiaries(memberID, state);
-        List<DiaryDTO> unknownMatchingDiary = matchingService.findUnknownDiary(memberID);
-
-        List<DiaryDTO> allDiaries = new ArrayList<>();
-        allDiaries.addAll(diaries);
-        allDiaries.addAll(unknownMatchingDiary);
+        List<DiaryDTO.unKnownMatchingDiary> unknownMatchingDiary = matchingService.findUnknownDiary(memberID);
 
         Map<String, Object> result = new HashMap<>();
-        result.put("total", allDiaries.size());
-        result.put("diaries", allDiaries);
+        result.put("total", diaries.size()+ unknownMatchingDiary.size());
+        result.put("diaries", diaries);
+        result.put("unmatchedDiaries", unknownMatchingDiary);
 
         return result;
     }

--- a/src/main/java/org/dallili/secretfriends/dto/DiaryDTO.java
+++ b/src/main/java/org/dallili/secretfriends/dto/DiaryDTO.java
@@ -51,5 +51,22 @@ public class DiaryDTO {
         private String color;
     }
 
+    @Data
+    @Builder
+    public static class unKnownMatchingDiary{
+        @NotNull
+        private Long diaryID; //get
+
+        @NotNull
+        private Long memberID; //get, set
+
+        private boolean state; //get, set
+
+        private String color; //get
+
+        private Long matchingID;
+
+    }
+
 
 }

--- a/src/main/java/org/dallili/secretfriends/service/MatchingService.java
+++ b/src/main/java/org/dallili/secretfriends/service/MatchingService.java
@@ -8,7 +8,7 @@ import java.util.Map;
 
 public interface MatchingService {
 
-    List<DiaryDTO> findUnknownDiary(Long memberID);
+    List<DiaryDTO.unKnownMatchingDiary> findUnknownDiary(Long memberID);
 
     Long addMatching(MatchingDTO matchingDTO);
 

--- a/src/main/java/org/dallili/secretfriends/service/MatchingServiceImpl.java
+++ b/src/main/java/org/dallili/secretfriends/service/MatchingServiceImpl.java
@@ -40,17 +40,20 @@ public class MatchingServiceImpl implements MatchingService{
 
 
     @Override
-    public List<DiaryDTO> findUnknownDiary(Long memberID) {
-        int matchingCount = matchingRepository.findAllByMemberID(memberID).size();
-        List<DiaryDTO> diaryDTOs = new ArrayList<>();
+    public List<DiaryDTO.unKnownMatchingDiary> findUnknownDiary(Long memberID) {
+
+        List<Matching> matchingList = matchingRepository.findAllByMemberID(memberID);
+        int matchingCount = matchingList.size();
+        List<DiaryDTO.unKnownMatchingDiary> diaryDTOs = new ArrayList<>();
 
         if(matchingCount > 0){
-            DiaryDTO diaryDTO = DiaryDTO.builder()
-                    .memberID(memberID)
-                    .color("#000000")
-                    .state(true)
-                    .build();
             for (int i=0; i<matchingCount; i++) {
+                DiaryDTO.unKnownMatchingDiary diaryDTO = DiaryDTO.unKnownMatchingDiary.builder()
+                        .memberID(memberID)
+                        .color("#000000")
+                        .state(true)
+                        .matchingID(matchingList.get(i).getMatchingID())
+                        .build();
                 diaryDTOs.add(diaryDTO);
             }
         }


### PR DESCRIPTION
## 작업 내용
- 일기장 목록 조회 시에 아직 매칭이 안된 일기장들이 matchingID 포함하도록 수정

## 테스트 내역
![image](https://github.com/Dallili/secretFriends-api/assets/99960721/a82f1b34-57a5-4d9b-8d56-0214194f4ab7)

unmatchedDiaries 출력형식 
![image](https://github.com/Dallili/secretFriends-api/assets/99960721/ecab4117-86b2-4674-87ae-4014a7b33b8c)
![image](https://github.com/Dallili/secretFriends-api/assets/99960721/e8e9e5be-7b93-4481-81aa-1836b440732c)
