### PR TITLE
[feat] 랜덤 매칭 미완료 일기장 컬러 수정, 일기장 목록 조회 리턴값 수정

### DIFF
--- a/src/main/java/org/dallili/secretfriends/controller/DiaryController.java
+++ b/src/main/java/org/dallili/secretfriends/controller/DiaryController.java
@@ -13,7 +13,6 @@ import org.dallili.secretfriends.service.MatchingService;
 import org.springframework.security.core.Authentication;
 import org.springframework.web.bind.annotation.*;
 
-import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -37,14 +36,14 @@ public class DiaryController {
     public Map<String, Object> diaryDTOList(@RequestParam("state") Boolean state, Authentication authentication) {
 
         Long memberID = Long.parseLong(authentication.getName());
+        Map<String, Object> result = diaryService.findStateDiaries(memberID, state);
 
-        List<DiaryDTO> diaries = diaryService.findStateDiaries(memberID, state);
-        List<DiaryDTO.unKnownMatchingDiary> unknownMatchingDiary = matchingService.findUnknownDiary(memberID);
-
-        Map<String, Object> result = new HashMap<>();
-        result.put("total", diaries.size()+ unknownMatchingDiary.size());
-        result.put("diaries", diaries);
-        result.put("unmatchedDiaries", unknownMatchingDiary);
+        if(state){ //활성 목록
+            List<DiaryDTO.unKnownMatchingDiary> unmatchedUnknownDiaries = matchingService.findUnknownDiary(memberID);
+            result.put("unmatchedUnknownDiaries", unmatchedUnknownDiaries);
+            int total = (Integer)result.get("total");
+            result.put("total", total+ unmatchedUnknownDiaries.size());
+        }
 
         return result;
     }

--- a/src/main/java/org/dallili/secretfriends/service/DiaryService.java
+++ b/src/main/java/org/dallili/secretfriends/service/DiaryService.java
@@ -4,6 +4,7 @@ import org.dallili.secretfriends.domain.Diary;
 import org.dallili.secretfriends.dto.DiaryDTO;
 
 import java.util.List;
+import java.util.Map;
 import java.util.UUID;
 
 public interface DiaryService {
@@ -22,7 +23,7 @@ public interface DiaryService {
 
     List<DiaryDTO> findAllDiaries(); //모든 일기장 목록 조회
 
-    List<DiaryDTO> findStateDiaries(Long memberID, Boolean state); // 활성화 or 비활성화된 상태의 일기장 목록 조회
+    Map<String,Object> findStateDiaries(Long memberID, Boolean state); // 활성화 or 비활성화된 상태의 일기장 목록 조회
 
     List<DiaryDTO> findRepliedDiaries(Long loginMemberID); // 답장 온 일기장 목록 조회
 

--- a/src/main/java/org/dallili/secretfriends/service/MatchingServiceImpl.java
+++ b/src/main/java/org/dallili/secretfriends/service/MatchingServiceImpl.java
@@ -48,9 +48,13 @@ public class MatchingServiceImpl implements MatchingService{
 
         if(matchingCount > 0){
             for (int i=0; i<matchingCount; i++) {
+                Random random = new Random();
+                int nextInt = random.nextInt(0xffffff + 1);
+                String randomColor = String.format("#%06x", nextInt);
+
                 DiaryDTO.unKnownMatchingDiary diaryDTO = DiaryDTO.unKnownMatchingDiary.builder()
                         .memberID(memberID)
-                        .color("#000000")
+                        .color(randomColor)
                         .state(true)
                         .matchingID(matchingList.get(i).getMatchingID())
                         .build();
@@ -161,6 +165,10 @@ public class MatchingServiceImpl implements MatchingService{
                 String oldMemberName = memberService.findMemberById(oldMemberID).getNickname();
                 String newMemberName = memberService.findMemberById(newMemberID).getNickname();
 
+                Random random = new Random();
+                int nextInt = random.nextInt(0xffffff + 1);
+                String randomColor = String.format("#%06x", nextInt);
+
                 DiaryDTO diaryDTO = DiaryDTO.builder()
                         .memberID(oldMemberID)
                         .partnerID(newMemberID)
@@ -168,7 +176,7 @@ public class MatchingServiceImpl implements MatchingService{
                         .partnerName(newMemberName)
                         .updatedAt(LocalDateTime.now())
                         .updatedBy(newMemberID)
-                        .color("#000000")
+                        .color(randomColor)
                         .build();
 
                 Long diaryID = diaryService.addDiary(diaryDTO); // 다이어리 생성

--- a/src/test/java/org/dallili/secretfriends/service/DiaryServiceTests.java
+++ b/src/test/java/org/dallili/secretfriends/service/DiaryServiceTests.java
@@ -11,6 +11,7 @@ import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
 
 import java.time.LocalDateTime;
 import java.util.List;
+import java.util.Map;
 import java.util.UUID;
 
 @SpringBootTest
@@ -101,7 +102,7 @@ public class DiaryServiceTests {
     @Test
     public void testFindStateDiaries(){
 
-        List<DiaryDTO> diaries = diaryService.findStateDiaries(2L, true);
+        Map<String, Object> diaries = diaryService.findStateDiaries(2L, true);
 
         log.info(diaries);
     }
@@ -109,7 +110,7 @@ public class DiaryServiceTests {
     @Test
     public void testFindRepliedDiaries() {
 
-        List<DiaryDTO> diaries = diaryService.findRepliedDiaries(100L);
+        List<DiaryDTO> diaries = diaryService.findRepliedDiaries(101L);
 
         log.info(diaries);
     }


### PR DESCRIPTION
## 작업 내용
- 기존에 "#000000"이던 일기장 컬러 랜덤하게 들어가도록 수정함
(단, 아직 매칭 완료 전 일기장은 컬러를 저장 해놓는건 아니라서, 조회할 때마다 컬러는 달라짐. 혹시 바뀌는게 별로면 고정되도록 수정하겠습니다,, )
- 프론트 요청에 따라 일기장 목록 조회 리턴 형식을 변경
 1) state == true일 경우 total, diaries, unmatchedUnknownDiaries, unmatchedKnownDiaries
 2) state == false일 경우 total, diaries

## 테스트 내역
![image](https://github.com/Dallili/secretFriends-api/assets/99960721/d57cc660-7f59-4ec3-a49e-b8cf2dddc5c8)
![image](https://github.com/Dallili/secretFriends-api/assets/99960721/647fac08-cbf6-4838-8e7a-fe489b6020a2)
![image](https://github.com/Dallili/secretFriends-api/assets/99960721/6b1c0da2-ad64-4bf3-9a4a-6475c246d5e2)
![image](https://github.com/Dallili/secretFriends-api/assets/99960721/d12fec57-a928-4008-88d2-0918cfa2fef0)
