### PR TITLE
[feat] 랜덤 매칭 미완료 일기장 컬러 고정

### DIFF
--- a/src/main/java/org/dallili/secretfriends/service/MatchingServiceImpl.java
+++ b/src/main/java/org/dallili/secretfriends/service/MatchingServiceImpl.java
@@ -48,9 +48,17 @@ public class MatchingServiceImpl implements MatchingService{
 
         if(matchingCount > 0){
             for (int i=0; i<matchingCount; i++) {
-                Random random = new Random();
-                int nextInt = random.nextInt(0xffffff + 1);
-                String randomColor = String.format("#%06x", nextInt);
+
+                LocalDateTime dateTime = matchingList.get(i).getCreatedAt();
+                int sum = dateTime.getHour() + dateTime.getMinute() + dateTime.getSecond();
+
+                String hexString = String.format("%04x", sum);
+                if (hexString.length() > 4) {
+                    hexString = hexString.substring(hexString.length() - 4);
+                }
+
+                hexString = hexString.toUpperCase();
+                String randomColor = "#FF" + hexString;
 
                 DiaryDTO.unKnownMatchingDiary diaryDTO = DiaryDTO.unKnownMatchingDiary.builder()
                         .memberID(memberID)


### PR DESCRIPTION
## 작업 내용
- 랜덤 매칭이 아직 완료되지 않은 일기장의 컬러를 따로 필드로 저장하지 않고 고정될 수 있도록 함.

## 구현 방법
- 랜덤 매칭의 요청 시간을 이용해서 컬러값을 hexcode로 계산.
