### PR TITLE
[feat] 랜덤 매칭 알고리즘 matchingHistory 반영하도록 수정

### DIFF
--- a/src/main/java/org/dallili/secretfriends/repository/MatchingHistoryRepository.java
+++ b/src/main/java/org/dallili/secretfriends/repository/MatchingHistoryRepository.java
@@ -3,5 +3,9 @@ package org.dallili.secretfriends.repository;
 import org.dallili.secretfriends.domain.MatchingHistory;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.List;
+
 public interface MatchingHistoryRepository extends JpaRepository<MatchingHistory, Long> {
+
+    List<MatchingHistory> findAllByMemberID(String memberID);
 }

--- a/src/main/java/org/dallili/secretfriends/service/MatchingHistoryService.java
+++ b/src/main/java/org/dallili/secretfriends/service/MatchingHistoryService.java
@@ -9,4 +9,6 @@ public interface MatchingHistoryService {
 
     Long addHistory(Long memberID, Long partnerID);
 
+    Boolean findHistory(Long memberID, Long partnerID);
+
 }

--- a/src/main/java/org/dallili/secretfriends/service/MatchingHistoryServiceImpl.java
+++ b/src/main/java/org/dallili/secretfriends/service/MatchingHistoryServiceImpl.java
@@ -9,6 +9,9 @@ import org.dallili.secretfriends.repository.MatchingHistoryRepository;
 import org.modelmapper.ModelMapper;
 import org.springframework.stereotype.Service;
 
+import java.util.List;
+import java.util.stream.Collectors;
+
 @Service
 @RequiredArgsConstructor
 @Log4j2
@@ -32,5 +35,20 @@ public class MatchingHistoryServiceImpl implements MatchingHistoryService{
         matchingHistoryRepository.save(matchingHistory);
 
         return matchingHistory.getHistoryID();
+    }
+
+    @Override
+    public Boolean findHistory(Long memberID, Long partnerID){
+
+        List<MatchingHistory> matchingHistories = matchingHistoryRepository.findAllByMemberID(String.valueOf(memberID)).stream()
+                .filter(matchingHistory -> Integer.parseInt(matchingHistory.getPartnerID()) == partnerID)
+                .collect(Collectors.toList());
+
+        List<MatchingHistory> matchingHistories2 = matchingHistoryRepository.findAllByMemberID(String.valueOf(partnerID)).stream()
+                .filter(matchingHistory -> Integer.parseInt(matchingHistory.getPartnerID()) == memberID)
+                .collect(Collectors.toList());
+
+        if (matchingHistories.isEmpty() && matchingHistories2.isEmpty()) return false;
+        else return true;
     }
 }

--- a/src/main/java/org/dallili/secretfriends/service/MatchingServiceImpl.java
+++ b/src/main/java/org/dallili/secretfriends/service/MatchingServiceImpl.java
@@ -114,10 +114,18 @@ public class MatchingServiceImpl implements MatchingService{
         List<Float> scoreList = new ArrayList<>();
 
         if (!matchingQueue.isEmpty()) {
-
+            // 매칭 점수 계산 (scoreList 완성)
             for (int i = 0; i < matchingQueue.size(); i++) {
 
                 Matching oldMatching = matchingQueue.get(i);
+                Long memberID = matchingQueue.get(i).getMemberID();
+
+                // 자기 자신의 매칭 요청이면 패스
+                // 이미 랜덤 매칭된 적 있는 상대면 패스
+                if(matchingHistoryService.findHistory(memberID, newUserID) || (memberID.equals(newUserID)))
+                {
+                    continue;
+                }
 
                 // 1. 웨이팅 타임 점수
                 LocalDateTime createdAt1 = oldMatching.getCreatedAt();
@@ -151,28 +159,24 @@ public class MatchingServiceImpl implements MatchingService{
                 scoreList.add(score);
             }
 
+            // 매칭 시작
             while(!scoreList.isEmpty()){
-                maxScore = Collections.max(scoreList); //
+                maxScore = Collections.max(scoreList);
+
+                // 매칭 실패
+                if(maxScore < scoreThreshold){
+                    break;
+                }
+
+                // 매칭 성공 (일정 점수 이상 이어야 한다는 조건 통과)
                 log.info("최종 최댓값: " + maxScore);
                 maxIndex = scoreList.indexOf(maxScore);
                 Long maxMatchingID = matchingQueue.get(maxIndex).getMatchingID();
                 Long oldMemberID = matchingQueue.get(maxIndex).getMemberID();
 
-                if(maxScore < scoreThreshold){
-                    break;
-                }
-
-                if(matchingHistoryService.findHistory(oldMemberID, newUserID))
-                {
-                   scoreList.remove(maxIndex);
-                   continue;
-                }
-
-                // 매칭 성공 (일정 점수 이상 이어야 한다는 조건 통과)
                 removeMatching(maxMatchingID); // 매칭 큐에서 삭제
-                Long newMemberID = newMatching.getMemberID();
                 String oldMemberName = memberService.findMemberById(oldMemberID).getNickname();
-                String newMemberName = memberService.findMemberById(newMemberID).getNickname();
+                String newMemberName = memberService.findMemberById(newUserID).getNickname();
 
                 Random random = new Random();
                 int nextInt = random.nextInt(0xffffff + 1);
@@ -180,25 +184,25 @@ public class MatchingServiceImpl implements MatchingService{
 
                 DiaryDTO diaryDTO = DiaryDTO.builder()
                         .memberID(oldMemberID)
-                        .partnerID(newMemberID)
+                        .partnerID(newUserID)
                         .memberName(oldMemberName)
                         .partnerName(newMemberName)
                         .updatedAt(LocalDateTime.now())
-                        .updatedBy(newMemberID)
+                        .updatedBy(newUserID)
                         .color(randomColor)
                         .build();
 
                 Long diaryID = diaryService.addDiary(diaryDTO); // 다이어리 생성
-                Long historyID = matchingHistoryService.addHistory(oldMemberID, newMemberID); // 매칭히스토리 생성
+                Long historyID = matchingHistoryService.addHistory(oldMemberID, newUserID); // 매칭히스토리 생성
 
                 result.put("state", true);
                 result.put("memberID", oldMemberID);
                 result.put("memberName", oldMemberName);
-                result.put("partnerID", newMemberID);
+                result.put("partnerID", newUserID);
                 result.put("partnerName", newMemberName);
                 result.put("diaryID", diaryID);
                 return result;
-                }
+            }
 
             // 매칭 실패 (점수 조건 통과 못함. 매칭큐에 추가해서 대기)
             Long newMatchingID = addMatching(newMatching);

--- a/src/test/java/org/dallili/secretfriends/service/MatchingServiceTests.java
+++ b/src/test/java/org/dallili/secretfriends/service/MatchingServiceTests.java
@@ -67,4 +67,10 @@ public class MatchingServiceTests {
 
         log.info(matchingService.findUnknownDiary(101L));
     }
+
+    @Test
+    public void testFindHistory(){
+
+        log.info(matchingHistoryService.findHistory(102L, 1L));
+    }
 }


### PR DESCRIPTION
## 작업 내용
- matchingHistory에 이미 있는 상대와는 매칭 안되도록 수정
- 자기 자신과도 매칭 안되도록 수정
- 최고점 매칭과 매칭 실패했을 경우(이미 history 있는 경우)
 while문 통해서 차순위 매칭으로 계속 매칭 시도하도록 함